### PR TITLE
mkdir -p sharedir before touch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ $(filter-out $(CUSTOM_INSTALL),$(OCRD_EXECUTABLES)):
 # clstm tesserocr
 $(SHARE)/%: % | $(ACTIVATE_VENV)
 	. $(ACTIVATE_VENV) && cd $< && $(PIP_INSTALL) .
+	@mkdir -p $(dir $@)
 	@touch $@
 
 # At last, add venv dependency (must not become first):

--- a/Makefile
+++ b/Makefile
@@ -258,10 +258,12 @@ $(filter-out $(CUSTOM_INSTALL),$(OCRD_EXECUTABLES)):
 
 # avoid making these .PHONY so they do not have to be repeated:
 # clstm tesserocr
-$(SHARE)/%: % | $(ACTIVATE_VENV)
+$(SHARE)/%: % | $(ACTIVATE_VENV) $(SHARE)
 	. $(ACTIVATE_VENV) && cd $< && $(PIP_INSTALL) .
-	@mkdir -p $(dir $@)
 	@touch $@
+
+$(SHARE):
+	@mkdir -p "$@"
 
 # At last, add venv dependency (must not become first):
 $(OCRD_EXECUTABLES) $(BIN)/wheel: | $(ACTIVATE_VENV)


### PR DESCRIPTION
Otherwise I get a build failure for `make ocrd-tesserocr-binarize` with a newly created venv.