### PR TITLE
LABEL the image with git rev, build date, maintainer, microbadger bad…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             docker push ocrd/all:minimum-git
             docker push ocrd/all:medium-git
             docker push ocrd/all:maximum-git
+            curl -X POST "$MICROBADGER_WEBHOOK" || true
 workflows:
   version: 2
   build-master:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,14 @@
 # use OCR-D base container (from ubuntu:18.04)
 FROM ocrd/core
 
-MAINTAINER OCR-D
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL \
+    maintainer="https://ocr-d.de/kontakt" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/OCR-D/ocrd_all" \
+    org.label-schema.build-date=$BUILD_DATE
+
 
 ENV PREFIX=/usr/local
 ENV VIRTUAL_ENV $PREFIX

--- a/Makefile
+++ b/Makefile
@@ -473,6 +473,8 @@ docker-maximum docker-maximum-git: DOCKER_MODULES = $(OCRD_MODULES)
 # (maybe we should add --network=host here for smoother build-time?)
 docker%: Dockerfile $(DOCKER_MODULES)
 	docker build \
+	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
+	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
 	--build-arg OCRD_MODULES="$(DOCKER_MODULES)" \
 	--build-arg PIP_OPTIONS="$(PIP_OPTIONS)" \
 	-t $(DOCKER_TAG):$(or $(*:-%=%),latest) .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OCR-D/ocrd_all
 
 [![Built on CircleCI](https://circleci.com/gh/OCR-D/ocrd_all.svg?style=svg)](https://circleci.com/gh/OCR-D/ocrd_all)
-![Docker Automated build](https://img.shields.io/docker/automated/ocrd/all)
 [![MIT licensed](https://img.shields.io/github/license/OCR-D/ocrd_all)](https://github.com/OCR-D/ocrd_all/blob/master/LICENSE)
+[![](https://images.microbadger.com/badges/image/ocrd/all:maximum.svg)](https://hub.docker.com/r/ocrd/all)
 
 This controls installation of all OCR-D modules from source (as git submodules).
 


### PR DESCRIPTION
Will add labels to the container with build date and git revision that can be inspected with `docker inspect` - might be useful for debugging. `MAINTAINER` is deprecated. Additional benefit is that this is compatible with microbadger which displays docker image info in a shields.io-like badge in the README.