### PR TITLE
cor-asv-fst: fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,12 @@ $(call multirule,$(OCRD_COR_ASV_ANN)): cor-asv-ann
 endif
 
 ifneq ($(findstring cor-asv-fst, $(OCRD_MODULES)),)
+deps-ubuntu: cor-asv-fst
 OCRD_EXECUTABLES += $(OCRD_COR_ASV_FST)
 OCRD_COR_ASV_FST := $(BIN)/ocrd-cor-asv-fst-process
 OCRD_COR_ASV_FST += $(BIN)/cor-asv-fst-train
 $(call multirule,$(OCRD_COR_ASV_FST)): cor-asv-fst
+	$(MAKE) -C $< deps
 	$(pip_install)
 endif
 


### PR DESCRIPTION
That should suffice to at least install cor-asv-fst properly. (It still does not make it [usable](https://github.com/ASVLeipzig/cor-asv-fst/blob/a0bc5f9f5196050c4c53ca58d0588aa42aaa1422/ocrd_cor_asv_fst/wrapper/decode.py#L237) though... so let's keep it deactivated here.)