### PR TITLE
DISABLED_MODULES, disable ocrd_kraken, clstm and ocrd_ocropy, fix #11, fix #21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,13 @@ export PKG_CONFIG_PATH
 OCRD_EXECUTABLES = $(BIN)/ocrd # add more CLIs below
 CUSTOM_DEPS = wget python3-venv # add more packages for deps-ubuntu below (or modules as preqrequisites)
 
+DISABLED_MODULES ?= cor-asv-fst opencv-python ocrd_kraken clstm ocrd_ocropy
 # Default to all submodules, but allow overriding by user
 # (and treat the empty value as if it was unset)
 # opencv-python is only needed for aarch64-linux-gnu and other less common platforms,
 # so don't include it by default.
-# XXX Wed Jan  8 13:21:44 CET 2020 kba - disabled cor-asv-fst since it won't build on 18.04 without hacks
 ifeq ($(strip $(OCRD_MODULES)),)
-override OCRD_MODULES := $(filter-out cor-asv-fst opencv-python,$(shell git submodule status | while read commit dir ref; do echo $$dir; done))
+override OCRD_MODULES := $(filter-out $(DISABLED_MODULES),$(shell git submodule status | while read commit dir ref; do echo $$dir; done))
 endif
 
 .DEFAULT_GOAL = help # all is too much for a default, and ocrd is too little
@@ -78,6 +78,7 @@ Variables:
 	PIP_OPTIONS: extra options for the `pip install` command like `-q` or `-v` or `-e`
 	GIT_RECURSIVE: set to `--recursive` to checkout/update all submodules recursively
 	OCRD_MODULES: list of submodules to include (defaults to all git submodules, see `show`)
+	DISABLED_MODULES: list of disabled modules. Default: $(DISABLED_MODULES)
 	TESSERACT_MODELS: list of additional models/languages to download for Tesseract
 EOF
 endef
@@ -365,7 +366,7 @@ fix-pip:
 		"pillow>=6.2.0" \
 		$$($(PIP) list | grep tensorflow-gpu | sed -E 's/-gpu +/==/')
 
-
+list of disabled modules. Default: $(DISABLED_MODULES)
 # At last, we know what all OCRD_EXECUTABLES are:
 all: $(OCRD_EXECUTABLES)
 show:

--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,6 @@ fix-pip:
 		"pillow>=6.2.0" \
 		$$($(PIP) list | grep tensorflow-gpu | sed -E 's/-gpu +/==/')
 
-list of disabled modules. Default: $(DISABLED_MODULES)
 # At last, we know what all OCRD_EXECUTABLES are:
 all: $(OCRD_EXECUTABLES)
 show:

--- a/README.md
+++ b/README.md
@@ -314,12 +314,21 @@ This table lists which tag contains which module:
 | ocrd_segment                | -         | ☑        | ☑         |
 | tesseract                   | -         | ☑        | ☑         |
 | ocrd_anybaseocr             | -         | -        | ☑         |
-| ocrd_kraken                 | -         | -        | ☑         |
-| ocrd_ocropy                 | -         | -        | ☑         |
 | ocrd_pc_segmentation        | -         | -        | ☑         |
 | ocrd_typegroups_classifier  | -         | -        | ☑         |
 | sbb_textline_detector       | -         | -        | ☑         |
-| cor-asv-fst                 | -         | -        | ☑         |
+| cor-asv-fst                 | -         | -        | -         |
+| clstm                       | -         | -        | -         |
+| ocrd_kraken                 | -         | -        | -         |
+| ocrd_ocropy                 | -         | -        | -         |
+
+**Note**: The following modules have been disabled by default and can only be
+enabled by explicitly setting the `DISABLED_MODULES`:
+
+* cor-asv-fst (runtime issues)
+* ocrd_ocropy (better implementation in ocrd_cis available)
+* ocrd_kraken (currently unmaintained)
+* clstm (required only for ocrd_kraken)
 
 
 ## Challenges
@@ -334,7 +343,6 @@ The following Python modules need an installation from code for different reason
 - cor-asv-ann (not available in PyPI)
 - cor-asv-fst (not available in PyPI)
 - dinglehopper (not available in PyPI)
-- ocrd_cis (not available in PyPI)
 - tesserocr (too old in PyPI)
 
 _(Solved by installation from source.)_
@@ -346,9 +354,6 @@ Modules may require mutually exclusive sets of dependent packages.
 
 `pip` does not even stop or resolve conflicts – it merely warns!
 
-- `Pillow`:
-   * `==5.4.1` (required by ocrd_typegroups_classifier)
-   * `>=6.2.0` (required by all others)
 - Tensorflow:
    * `tensorflow-gpu==1.14.0` (required by ocrd_calamari and ocrd_anybaseocr)
    * `tensorflow` (required by cor-asv-ann and ocrd_keraslm)

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ This table lists which tag contains which module:
 | ocrd_ocropy                 | -         | -        | -         |
 
 **Note**: The following modules have been disabled by default and can only be
-enabled by explicitly setting the `DISABLED_MODULES`:
+enabled by explicitly setting `OCRD_MODULES` or `DISABLED_MODULES`:
 
 * cor-asv-fst (runtime issues)
 * ocrd_ocropy (better implementation in ocrd_cis available)


### PR DESCRIPTION
This implements @stweil's proposed `DISABLED_MODULES` and disables ocrd_kraken, clstm and ocrd_ocropy. That way, they are still present for the more curious and brave user but won't be installed by default.