### PR TITLE
[app][fix] prevent imagemagick cache exhausted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ RUN ldconfig
 # remove (dated) security workaround preventing use of
 # ImageMagick's convert on PDF/PS/EPS/XPS:
 RUN sed -i 's/rights="none"/rights="read|write"/g' /etc/ImageMagick-6/policy.xml
+# prevent cache resources exhausted errors
+RUN sed -i 's/name="disk" value="1GiB"/name="disk" value="4GiB"/g' /etc/ImageMagick-6/policy.xml
 
 # reset to interactive
 ENV DEBIAN_FRONTEND teletype


### PR DESCRIPTION
To process large Images, like newspaper pages, the current ImageMagick defaults are insufficient.

They result into errors like this when used with modules like `ocrd_im6convert`or `ocrd_olena`:

```
+ docker run -u 1000 -w /data -v /home/m3ssman/Projects/ulb/ulb-dd-ocr-eval-ocrd/ocrd-work:/data -v /usr/share/tesseract-ocr/4.00/tessdata:/usr/local/share/tessdata/ ocrd/all:medium ocrd-make -f ulb-ocrd-newspaper.mk .
make: Entering directory '/data'
make -R -C . -I /data/ -f /data/ulb-ocrd-newspaper.mk  2>&1 | tee ..ulb-ocrd-newspaper.log
make[1]: Entering directory '/data'
building OCR-D-BINPAGE-sauvola from MAX with pattern rule for ocrd-olena-binarize
ocrd workspace remove-group -r OCR-D-BINPAGE-sauvola 2>/dev/null || true
ocrd-olena-binarize -I MAX -O OCR-D-BINPAGE-sauvola -p OCR-D-BINPAGE-sauvola.json 2>&1 | tee OCR-D-BINPAGE-sauvola.log && touch -c OCR-D-BINPAGE-sauvola || { rm -fr OCR-D-BINPAGE-sauvola.json OCR-D-BINPAGE-sauvola; exit 1; }
13:44:55.828 INFO ocrd-olena-binarize - No output file group for images specified, falling back to 'OCR-D-IMG-BIN'
13:44:56.389 INFO ocrd-olena-binarize - processing image/png input file 1667522809_J_0001_0002 ()
terminate called after throwing an instance of 'Magick::ErrorCache'
  what():  sauvola_ms_split: cache resources exhausted `MAX/1667522809_J_0001_0002.png' @ error/cache.c/OpenPixelCache/3984
Aborted (core dumped)
Makefile:304: recipe for target 'OCR-D-BINPAGE-sauvola' failed
make[1]: *** [OCR-D-BINPAGE-sauvola] Error 1
make[1]: Leaving directory '/data'
make: *** [.] Error 2
Makefile:194: recipe for target '.' failed
make: Leaving directory '/data'
```

To prevent these, it is necessary at least to increase the disk settings. In the case with `ocrd_olena`, increasing from 1GiB to 4 GiB did the job.
