### PR TITLE
make install-models to install commonly used models for tesseract, ocropy, calamari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# CHANGELOG
+
+## 2020-05-31
+
+Update:
+
+  * `ocrd_olena`: e000f24 (1.1.7)
+  * `tesseract`: 62eae84
+  * `ocrd_cis`: a6a2ecd
+
+Added:
+
+  * `CHANGELOG.md` to track changes

--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,8 @@ CUSTOM_DEPS += g++ make automake libleptonica-dev
 # but since we are building statically, we need more (static) libs at build time
 CUSTOM_DEPS += libarchive-dev libcurl4-nss-dev libgif-dev libjpeg-dev libpng-dev libtiff-dev
 
-TESSDATA := $(VIRTUAL_ENV)/share/tessdata
+TESSDATA_PREFIX ?= $(VIRTUAL_ENV)/share
+TESSDATA := $(TESSDATA_PREFIX)/tessdata
 TESSDATA_URL := https://github.com/tesseract-ocr/tessdata_fast
 TESSERACT_TRAINEDDATA = $(ALL_TESSERACT_MODELS:%=$(TESSDATA)/%.traineddata)
 
@@ -431,17 +432,43 @@ install-models: \
 	install-models-ocropus \
 	install-models-calamari
 
-UB_MANNHEIM_BACKUP_URL = https://ub-backup.bib.uni-mannheim.de/~stweil/ocrd-train/data/Fraktur_5000000
+UB_MANNHEIM_BACKUP_URL = https://ub-backup.bib.uni-mannheim.de/~stweil/ocrd-train/data
 .PHONY: install-models-tesseract
 install-models-tesseract: \
+	$(ALL_TESSERACT_MODELS:%=%.traineddata) \
+	frk.traineddata \
+	deu.traineddata \
+	script/Fraktur.traineddata \
+	script/Latin.traineddata \
+	$(TESSDATA)/GT4HistOCR_100000.traineddata \
+	$(TESSDATA)/GT4HistOCR_300000.traineddata \
+	$(TESSDATA)/GT4HistOCR_2000000.traineddata \
 	$(TESSDATA)/fast/Fraktur_50000000.334_450937.traineddata \
 	$(TESSDATA)/best/Fraktur_50000000.334_450937.traineddata
+	@if test -z "$(TESSDATA_PREFIX)";then \
+		echo "Update your shell startup file to set the 'TESSDATA_PREFIX' environment variable:" ;\
+		echo "bash: Add to $$HOME/.bashrc:" ;\
+		echo "      export TESSDATA_PREFIX='$(TESSDATA_PREFIX)'" ;\
+		echo "zsh: Add to $$HOME/.zshrc:" ;\
+		echo "      export TESSDATA_PREFIX='$(TESSDATA_PREFIX)'" ;\
+		echo "fish: Add to $$HOME/.config/fish/fish.config:" ;\
+		echo "      setenv TESSDATA_PREFIX '$(TESSDATA_PREFIX)'" ;\
+	fi
+
+$(TESSDATA)/GT4HistOCR_100000.traineddata:
+	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/$(notdir $@))
+
+$(TESSDATA)/GT4HistOCR_300000.traineddata:
+	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/$(notdir $@))
+
+$(TESSDATA)/GT4HistOCR_2000000.traineddata:
+	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/$(notdir $@))
 
 $(TESSDATA)/fast/Fraktur_50000000.334_450937.traineddata:
-	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/tessdata_fast/Fraktur_50000000.334_450937.traineddata)
+	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/Fraktur_5000000/tessdata_fast/Fraktur_50000000.334_450937.traineddata)
 
 $(TESSDATA)/best/Fraktur_50000000.334_450937.traineddata:
-	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/tessdata_best/Fraktur_50000000.334_450937.traineddata)
+	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/Fraktur_5000000/tessdata_best/Fraktur_50000000.334_450937.traineddata)
 
 OCROPUS_DATA_PATH := $(VIRTUAL_ENV)/share/ocropus
 .PHONY: install-models-ocropus

--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,7 @@ TESSERACT_TRAINEDDATA = $(ALL_TESSERACT_MODELS:%=$(TESSDATA)/%.traineddata)
 stripdir = $(patsubst %/,%,$(dir $(1)))
 
 # {{{ Install commonly used models
-.PHONY: install-tesseract
+.PHONY: install-models
 install-models: \
 	install-models-tesseract \
 	install-models-ocropus \

--- a/Makefile
+++ b/Makefile
@@ -503,9 +503,9 @@ $(OCROPUS_DATA_PATH)/LatinHist-98000.pyrnn.gz:
 CALAMARI_DATA_PATH := $(VIRTUAL_ENV)/share/calamari
 .PHONY: install-models-calamari
 install-models-calamari: \
-	$(CALAMARI_DATA_PATH)/gt4histocr-qurator/checkpoint
+	$(CALAMARI_DATA_PATH)/GT4HistOCR/checkpoint
 
-$(CALAMARI_DATA_PATH)/gt4histocr-qurator/checkpoint:
+$(CALAMARI_DATA_PATH)/GT4HistOCR/checkpoint:
 	mkdir -p $(dir $@)
 	$(call WGET,/tmp/gt4histocr-qurator.tar.xz,https://qurator-data.de/calamari-models/GT4HistOCR/model.tar.xz)
 	cd $(dir $@) && tar xf /tmp/gt4histocr-qurator.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -429,19 +429,19 @@ stripdir = $(patsubst %/,%,$(dir $(1)))
 install-models: \
 	install-models-tesseract \
 	install-models-ocropus \
-	install-models-calamari \
+	install-models-calamari
 
 UB_MANNHEIM_BACKUP_URL = https://ub-backup.bib.uni-mannheim.de/~stweil/ocrd-train/data/Fraktur_5000000
 .PHONY: install-models-tesseract
 install-models-tesseract: \
-	$(TESSDATA)/Fraktur_50000000.334_450937-fast.traineddata \
-	$(TESSDATA)/Fraktur_50000000.334_450937-best.traineddata
+	$(TESSDATA)/fast/Fraktur_50000000.334_450937.traineddata \
+	$(TESSDATA)/best/Fraktur_50000000.334_450937.traineddata
 
-$(TESSDATA)/Fraktur_50000000.334_450937-fast.traineddata:
-	$(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/tessdata_fast/Fraktur_50000000.334_450937.traineddata)
+$(TESSDATA)/fast/Fraktur_50000000.334_450937.traineddata:
+	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/tessdata_fast/Fraktur_50000000.334_450937.traineddata)
 
-$(TESSDATA)/Fraktur_50000000.334_450937-best.traineddata:
-	$(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/tessdata_best/Fraktur_50000000.334_450937.traineddata)
+$(TESSDATA)/best/Fraktur_50000000.334_450937.traineddata:
+	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/tessdata_best/Fraktur_50000000.334_450937.traineddata)
 
 OCROPUS_DATA_PATH := $(VIRTUAL_ENV)/share/ocropus
 .PHONY: install-models-ocropus

--- a/Makefile
+++ b/Makefile
@@ -418,8 +418,7 @@ CUSTOM_DEPS += g++ make automake libleptonica-dev
 # but since we are building statically, we need more (static) libs at build time
 CUSTOM_DEPS += libarchive-dev libcurl4-nss-dev libgif-dev libjpeg-dev libpng-dev libtiff-dev
 
-TESSDATA_PREFIX ?= $(VIRTUAL_ENV)/share
-TESSDATA := $(TESSDATA_PREFIX)/tessdata
+TESSDATA := $(VIRTUAL_ENV)/share/tessdata
 TESSDATA_URL := https://github.com/tesseract-ocr/tessdata_fast
 TESSERACT_TRAINEDDATA = $(ALL_TESSERACT_MODELS:%=$(TESSDATA)/%.traineddata)
 
@@ -445,15 +444,6 @@ install-models-tesseract: \
 	$(TESSDATA)/GT4HistOCR_2000000.traineddata \
 	$(TESSDATA)/fast/Fraktur_50000000.334_450937.traineddata \
 	$(TESSDATA)/best/Fraktur_50000000.334_450937.traineddata
-	@if test -z "$(TESSDATA_PREFIX)";then \
-		echo "Update your shell startup file to set the 'TESSDATA_PREFIX' environment variable:" ;\
-		echo "bash: Add to $$HOME/.bashrc:" ;\
-		echo "      export TESSDATA_PREFIX='$(TESSDATA_PREFIX)'" ;\
-		echo "zsh: Add to $$HOME/.zshrc:" ;\
-		echo "      export TESSDATA_PREFIX='$(TESSDATA_PREFIX)'" ;\
-		echo "fish: Add to $$HOME/.config/fish/fish.config:" ;\
-		echo "      setenv TESSDATA_PREFIX '$(TESSDATA_PREFIX)'" ;\
-	fi
 
 $(TESSDATA)/GT4HistOCR_100000.traineddata:
 	mkdir -p $(dir $@); $(call WGET,$@,$(UB_MANNHEIM_BACKUP_URL)/$(notdir $@))

--- a/Makefile
+++ b/Makefile
@@ -450,14 +450,27 @@ install-models-ocropus: \
 	$(OCROPUS_DATA_PATH)/fraktur.pyrnn.gz \
 	$(OCROPUS_DATA_PATH)/fraktur-jze.pyrnn.gz \
 	$(OCROPUS_DATA_PATH)/LatinHist-98000.pyrnn.gz
+	@if test -z "$(OCROPUS_DATA)";then \
+		echo "Update your shell startup file to set the 'OCROPUS_DATA' environment variable:" ;\
+		echo "bash: Add to $$HOME/.bashrc:" ;\
+		echo "      export OCROPUS_DATA='$(OCROPUS_DATA_PATH)'" ;\
+		echo "zsh: Add to $$HOME/.zshrc:" ;\
+		echo "      export OCROPUS_DATA='$(OCROPUS_DATA_PATH)'" ;\
+		echo "fish: Add to $$HOME/.config/fish/fish.config:" ;\
+		echo "      setenv OCROPUS_DATA '$(OCROPUS_DATA_PATH)'" ;\
+	fi
 
 $(OCROPUS_DATA_PATH)/en-default.pyrnn.gz:
-	$(call WGET,https://github.com/zuphilip/ocropy-models/raw/master/$(notdir $@))
+	mkdir -p $(dir $@)
+	$(call WGET,$@,https://github.com/zuphilip/ocropy-models/raw/master/$(notdir $@))
 $(OCROPUS_DATA_PATH)/fraktur.pyrnn.gz:
-	$(call WGET,https://github.com/zuphilip/ocropy-models/raw/master/$(notdir $@))
+	mkdir -p $(dir $@)
+	$(call WGET,$@,https://github.com/zuphilip/ocropy-models/raw/master/$(notdir $@))
 $(OCROPUS_DATA_PATH)/fraktur-jze.pyrnn.gz:
-	$(call WGET,https://github.com/jze/ocropus-model_fraktur/blob/master/fraktur.pyrnn.gz)
+	mkdir -p $(dir $@)
+	$(call WGET,$@,https://github.com/jze/ocropus-model_fraktur/blob/master/fraktur.pyrnn.gz)
 $(OCROPUS_DATA_PATH)/LatinHist-98000.pyrnn.gz:
+	mkdir -p $(dir $@)
 	$(call WGET,$@,https://github.com/chreul/OCR_Testdata_EarlyPrintedBooks/raw/master/LatinHist-98000.pyrnn.gz)
 
 CALAMARI_DATA_PATH := $(VIRTUAL_ENV)/share/calamari

--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ $(OCROPUS_DATA_PATH)/fraktur.pyrnn.gz:
 	$(call WGET,$@,https://github.com/zuphilip/ocropy-models/raw/master/$(notdir $@))
 $(OCROPUS_DATA_PATH)/fraktur-jze.pyrnn.gz:
 	mkdir -p $(dir $@)
-	$(call WGET,$@,https://github.com/jze/ocropus-model_fraktur/blob/master/fraktur.pyrnn.gz)
+	$(call WGET,$@,https://github.com/jze/ocropus-model_fraktur/raw/master/fraktur.pyrnn.gz)
 $(OCROPUS_DATA_PATH)/LatinHist-98000.pyrnn.gz:
 	mkdir -p $(dir $@)
 	$(call WGET,$@,https://github.com/chreul/OCR_Testdata_EarlyPrintedBooks/raw/master/LatinHist-98000.pyrnn.gz)


### PR DESCRIPTION
Adds targets `install-models{,-tesseract,-ocropy,-calamari}` to install recognition models by @stweil, @mikegerber, @jze, @chreul to sensible locations in `$(VIRTUAL_ENV)/share`.

The list of installed models is far from exhaustive and can/should be easily amended. 

This is a stopgap solution until we have a proper model repository. I had to re-download models over the last two weeks for different environments and I thought I might as well create a script and `ocrd_all` seemed like a good place.

I tried to use GitHub locations where possible. If potential traffic spikes from adding model download here are of concern, I can set up a mirror.