### PR TITLE
Avoid repeated Tesseract builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -649,12 +649,12 @@ $(TESSDATA)/%.traineddata:
 	$(call WGET,$@,$(TESSDATA_URL)/raw/master/$(notdir $(call stripdir,$@))/$(notdir $@)) || \
 		{ $(RM) $@; false; }
 
-tesseract/configure: tesseract
+tesseract/Makefile.in: tesseract
 	cd tesseract && ./autogen.sh
 
 # Build and install Tesseract.
 TESSERACT_CONFIG ?= --disable-openmp --disable-shared CXXFLAGS="-g -O2 -fPIC"
-$(BIN)/tesseract: tesseract/configure
+$(BIN)/tesseract: tesseract/Makefile.in
 	mkdir -p $(VIRTUAL_ENV)/build/tesseract
 	cd $(VIRTUAL_ENV)/build/tesseract && $(CURDIR)/tesseract/configure --prefix="$(VIRTUAL_ENV)" $(TESSERACT_CONFIG)
 	cd $(VIRTUAL_ENV)/build/tesseract && $(MAKE) install
@@ -681,7 +681,7 @@ TESSTRAIN_EXECUTABLES += $(BIN)/wordlist2dawg
 .PHONY: install-tesseract-training
 install-tesseract-training: $(TESSTRAIN_EXECUTABLES)
 
-$(call multirule,$(TESSTRAIN_EXECUTABLES)): tesseract/configure
+$(call multirule,$(TESSTRAIN_EXECUTABLES)): tesseract/Makefile.in
 	mkdir -p $(VIRTUAL_ENV)/build/tesseract
 	$(MAKE) -C $(VIRTUAL_ENV)/build/tesseract training-install
 


### PR DESCRIPTION
Running autogen.sh creates a new configure file. That updates the timestamp for tesseract.
With the dependency introduced in commit e1b30b95, that triggered a new run of autogen.sh
when make was run again and so on.

Signed-off-by: Stefan Weil <sw@weilnetz.de>