### PR TITLE
expose variable for Tesseract configure params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ Variables:
 	OCRD_MODULES: list of submodules to include (defaults to all git submodules, see `show`)
 	DISABLED_MODULES: list of disabled modules. Default: $(DISABLED_MODULES)
 	TESSERACT_MODELS: list of additional models/languages to download for Tesseract
+	TESSERACT_CONFIG: command line options for Tesseract `configure`. Default: $(TESSERACT_CONFIG)
 EOF
 endef
 export HELP
@@ -463,9 +464,10 @@ tesseract/configure: tesseract
 	cd tesseract && ./autogen.sh
 
 # Build and install Tesseract.
+TESSERACT_CONFIG ?= --disable-openmp --disable-shared CXXFLAGS="-g -O2 -fPIC"
 $(BIN)/tesseract: tesseract/configure
 	mkdir -p $(VIRTUAL_ENV)/build/tesseract
-	cd $(VIRTUAL_ENV)/build/tesseract && $(CURDIR)/tesseract/configure --disable-openmp --disable-shared --prefix="$(VIRTUAL_ENV)" CXXFLAGS="-g -O2 -fPIC"
+	cd $(VIRTUAL_ENV)/build/tesseract && $(CURDIR)/tesseract/configure --prefix="$(VIRTUAL_ENV)" $(TESSERACT_CONFIG)
 	cd $(VIRTUAL_ENV)/build/tesseract && $(MAKE) install
 
 # Build and install Tesseract training tools.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ in the current shell environment via PATH and PYTHONHOME.)
        * [<em>PIP_OPTIONS</em>](#pip_options)
        * [<em>GIT_RECURSIVE</em>](#git_recursive)
        * [<em>TESSERACT_MODELS</em>](#tesseract_models)
+       * [<em>TESSERACT_CONFIG</em>](#tesseract_config)
     * [Examples](#examples)
     * [Results](#results)
     * [Persistent configuration](#persistent-configuration)
@@ -203,6 +204,10 @@ Set to `--recursive` to checkout/update all modules recursively. (This usually i
 #### _TESSERACT_MODELS_
 
 Add more models to the minimum required list of languages (`eng equ osd`) to install along with Tesseract.
+
+#### _TESSERACT_CONFIG_
+
+Set `configure` options for building Tesseract from source (`--disable-openmp --disable-shared CXXFLAGS="-g -O2 -fPIC"`).
 
 ### Examples
 


### PR DESCRIPTION
Fix #127 

As [discussed](https://github.com/OCR-D/ocrd_all/issues/127#issuecomment-659358910), this allows building Tesseract in other ways (including the static/shared decision etc).