### PR TITLE
:fire: exclude tesseract-ocr-equ from CUSTOM_DEPS, fix #133

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ ifeq ($(findstring tesseract, $(OCRD_MODULES)),)
 deps-ubuntu: ocrd_tesserocr
 # convert Tesseract model names into Ubuntu/Debian pkg names
 # (does not work with names under script/ though)
-CUSTOM_DEPS += $(subst _,-,$(ALL_TESSERACT_MODELS:%=tesseract-ocr-%))
+CUSTOM_DEPS += $(filter-out tesseract-ocr-equ,$(subst _,-,$(ALL_TESSERACT_MODELS:%=tesseract-ocr-%)))
 CUSTOM_DEPS += libarchive-dev
 endif
 


### PR DESCRIPTION
Will merge this quickly because the problem is not triggered in the PR build. I'll keep #133 open though so we can find a better solution. But for now, I want the docker images building again ASAP.