### PR TITLE
support Docker additional variants based on ocrd/core-cuda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,12 @@ jobs:
       - run: make docker-minimum-git
       - run: make docker-medium-git
       - run: make docker-maximum-git
+      - run: make docker-minimum-cuda
+      - run: make docker-medium-cuda
+      - run: make docker-maximum-cuda
+      - run: make docker-minimum-cuda-git
+      - run: make docker-medium-cuda-git
+      - run: make docker-maximum-cuda-git
       - run:
           name: Login to Docker Hub
           command: echo "$DOCKERHUB_PASS" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
@@ -36,6 +42,18 @@ jobs:
             docker push ocrd/all:maximum &
             jobs+=($!)
             docker push ocrd/all:maximum-git &
+            jobs+=($!)
+            docker push ocrd/all:minimum-cuda &
+            jobs=($!)
+            docker push ocrd/all:minimum-cuda-git &
+            jobs+=($!)
+            docker push ocrd/all:medium-cuda &
+            jobs+=($!)
+            docker push ocrd/all:medium-cuda-git &
+            jobs+=($!)
+            docker push ocrd/all:maximum-cuda &
+            jobs+=($!)
+            docker push ocrd/all:maximum-cuda-git &
             jobs+=($!)
             while sleep 60; ps -p "${jobs[*]}"; do :; done
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,12 @@
 # - danger of running into inconsistent dependencies
 #   between modules (just as ocrd_all for local installation)
 
-# use OCR-D base container (from ubuntu:18.04)
-FROM ocrd/core
-
 ARG VCS_REF
 ARG BUILD_DATE
+ARG BASE_IMAGE
+
+# use OCR-D base container (from ubuntu:18.04)
+FROM $BASE_IMAGE
 LABEL \
     maintainer="https://ocr-d.de/kontakt" \
     org.label-schema.vcs-ref=$VCS_REF \

--- a/Makefile
+++ b/Makefile
@@ -738,11 +738,11 @@ endif
 docker-%-git: PIP_OPTIONS = -e
 
 # Minimum-size selection: use Ocropy binarization, use Tesseract from PPA
-docker-minimum%: DOCKER_MODULES = core ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_tesserocr ocrd_wrap tesserocr workflow-configuration
+docker-mini%: DOCKER_MODULES = core ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_tesserocr ocrd_wrap tesserocr workflow-configuration
 # Medium-size selection: add Olena binarization and Calamari, use Tesseract from git, add evaluation
-docker-medium%: DOCKER_MODULES = core cor-asv-ann dinglehopper format-converters ocrd_calamari ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_keraslm ocrd_olena ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_segment ocrd_tesserocr ocrd_wrap tesseract tesserocr workflow-configuration
+docker-medi%: DOCKER_MODULES = core cor-asv-ann dinglehopper format-converters ocrd_calamari ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_keraslm ocrd_olena ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_segment ocrd_tesserocr ocrd_wrap tesseract tesserocr workflow-configuration
 # Maximum-size selection: use all modules
-docker-maximum%: DOCKER_MODULES = $(OCRD_MODULES)
+docker-maxi%: DOCKER_MODULES = $(OCRD_MODULES)
 
 # DOCKER_BASE_IMAGE
 docker%um docke%um-git: DOCKER_BASE_IMAGE = ocrd/core

--- a/Makefile
+++ b/Makefile
@@ -728,26 +728,32 @@ DOCKER_TAG ?= ocrd/all
 #  so build-time and bandwidth are n-fold)
 .PHONY: dockers
 ifdef DOCKERS_WITHOUT_REPOS
-dockers: docker-minimum docker-medium docker-maximum
+dockers: docker-minimum docker-minimum-cuda docker-medium docker-medium-cuda docker-maximum docker-maximum-cuda
 else
-dockers: docker-minimum-git docker-medium-git docker-maximum-git
+dockers: docker-minimum-git docker-minimum-cuda-git docker-medium-git docker-medium-cuda-git docker-maximum-git docker-maximum-cuda-git
 endif
 
 # Selections which keep git repos and reference them for install
 # (so components can be updated via git from the container alone)
-docker-minimum-git docker-medium-git docker-maximum-git: PIP_OPTIONS = -e
+docker-%-git: PIP_OPTIONS = -e
 
 # Minimum-size selection: use Ocropy binarization, use Tesseract from PPA
-docker-minimum docker-minimum-git: DOCKER_MODULES = core ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_tesserocr ocrd_wrap tesserocr workflow-configuration
+docker-minimum%: DOCKER_MODULES = core ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_tesserocr ocrd_wrap tesserocr workflow-configuration
 # Medium-size selection: add Olena binarization and Calamari, use Tesseract from git, add evaluation
-docker-medium docker-medium-git: DOCKER_MODULES = core cor-asv-ann dinglehopper format-converters ocrd_calamari ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_keraslm ocrd_olena ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_segment ocrd_tesserocr ocrd_wrap tesseract tesserocr workflow-configuration
+docker-medium%: DOCKER_MODULES = core cor-asv-ann dinglehopper format-converters ocrd_calamari ocrd_cis ocrd_fileformat ocrd_im6convert ocrd_keraslm ocrd_olena ocrd_pagetopdf ocrd_repair_inconsistencies ocrd_segment ocrd_tesserocr ocrd_wrap tesseract tesserocr workflow-configuration
 # Maximum-size selection: use all modules
-docker-maximum docker-maximum-git: DOCKER_MODULES = $(OCRD_MODULES)
+docker-maximum%: DOCKER_MODULES = $(OCRD_MODULES)
+
+# DOCKER_BASE_IMAGE
+docker%um docke%um-git: DOCKER_BASE_IMAGE = ocrd/core
+# CUDA variants
+docker%-cuda docker%-cuda-git: DOCKER_BASE_IMAGE = ocrd/core-cuda
 
 # Build rule for all selections
 # (maybe we should add --network=host here for smoother build-time?)
 docker%: Dockerfile $(DOCKER_MODULES)
 	docker build \
+	--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
 	--build-arg OCRD_MODULES="$(DOCKER_MODULES)" \


### PR DESCRIPTION
Once we merge https://github.com/OCR-D/core/pull/454, there will be an additional `ocrd/core-cuda` base image based on [nvidia/cuda:11.0-base-ubuntu18.04](https://hub.docker.com/layers/nvidia/cuda/11.0-base-ubuntu18.04/images/sha256-d2ad87954a40fa4671e81df1fac5989448323bfa846ced05898058b1805b3723?context=explore). We can then create CUDA-capable variants of ocrd_all Docker images.

We'll need to investigate parallelization for the CI/CD because otherwise this will double the build time.