### PR TITLE
Update release.sh to use git pull --rebase

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -78,8 +78,8 @@ update_one_submodule () {
     local branch="master"
     (
         cd $sm
-        git pull origin "$branch"
-        git pull origin "$branch" --tags
+        git pull --rebase origin "$branch"
+        git pull --rebase origin "$branch" --tags
         git submodule update --init
      )
 }


### PR DESCRIPTION
This avoids a warning from git:

    warning: Pulling without specifying how to reconcile divergent branches is
    discouraged.

Signed-off-by: Stefan Weil <sw@weilnetz.de>