### PR TITLE
CircleCI deploy parallel push: terminate after last job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,30 +32,18 @@ jobs:
           name: Push images to Docker Hub in parallel
           command: |
             docker push ocrd/all:minimum &
-            jobs=($!)
             docker push ocrd/all:minimum-git &
-            jobs+=($!)
             docker push ocrd/all:medium &
-            jobs+=($!)
             docker push ocrd/all:medium-git &
-            jobs+=($!)
             docker push ocrd/all:maximum &
-            jobs+=($!)
             docker push ocrd/all:maximum-git &
-            jobs+=($!)
             docker push ocrd/all:minimum-cuda &
-            jobs=($!)
             docker push ocrd/all:minimum-cuda-git &
-            jobs+=($!)
             docker push ocrd/all:medium-cuda &
-            jobs+=($!)
             docker push ocrd/all:medium-cuda-git &
-            jobs+=($!)
             docker push ocrd/all:maximum-cuda &
-            jobs+=($!)
             docker push ocrd/all:maximum-cuda-git &
-            jobs+=($!)
-            while sleep 60; ps -p "${jobs[*]}"; do :; done
+            while jobs -pr | { read PIDS && echo $PIDS; }; do sleep 60; done
       - run:
           name: Create a date-versioned mirror of ocrd/all:maximum
           command: bash release.sh release-dockerhub


### PR DESCRIPTION
(I wonder why this could have ever worked before. I was only alerted to this by [a recent failure](https://app.circleci.com/pipelines/github/OCR-D/ocrd_all/371/workflows/1704573c-c4eb-4780-af4c-313d89a1930c/jobs/371), which should not have occured that way either...)

Also, I don't understand why CircleCI's "restart from failed" does not restart from the failed step, but repeats the whole job.

Anyway, be warned I cannot test this outside of the CI, so expect a total breakdown!