### PR TITLE
Docker prefix path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,9 @@ LABEL \
     org.label-schema.build-date=$BUILD_DATE
 
 
-ENV PREFIX=/usr/local
+# simulate a virtual env for the makefile,
+# coinciding with the Python system prefix
+ENV PREFIX=/usr
 ENV VIRTUAL_ENV $PREFIX
 
 # make apt run non-interactive during build
@@ -65,7 +67,7 @@ RUN echo "Acquire::ftp::Timeout \"3000\";" >> /etc/apt/apt.conf.d/99network
 RUN echo "set -ex" > docker.sh
 # get packages for build
 RUN echo "apt-get -y install automake autoconf libtool pkg-config g++" >> docker.sh
-# we want to use PREFIX as venv
+# we want to use PREFIX as "venv", so we need activate (as no-op)
 RUN echo "> $PREFIX/bin/activate" >> docker.sh
 # try to fetch all modules system requirements
 RUN echo "make deps-ubuntu" >> docker.sh

--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ $(OCRD_PC_SEGMENTATION): ocrd_pc_segmentation $(BIN)/ocrd
 ifeq (0,$(MAKELEVEL))
 	$(MAKE) -B -o $< $(notdir $(OCRD_PC_SEGMENTATION))
 	$(call delegate_venv,$(OCRD_PC_SEGMENTATION))
-$(OCRD_PC_SEGMENTATION): VIRTUAL_ENV := $(SUB_VENV)/headless-tf21
+$(OCRD_PC_SEGMENTATION): VIRTUAL_ENV := $(SUB_VENV)/headless-tf2
 else
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
 	$(pip_install)
@@ -415,7 +415,7 @@ $(call multirule,$(OCRD_ANYBASEOCR)): ocrd_anybaseocr $(BIN)/ocrd
 ifeq (0,$(MAKELEVEL))
 	$(MAKE) -B -o $< $(notdir $(OCRD_ANYBASEOCR))
 	$(call delegate_venv,$(OCRD_ANYBASEOCR))
-$(OCRD_ANYBASEOCR): VIRTUAL_ENV := $(SUB_VENV)/headless-tf22
+$(OCRD_ANYBASEOCR): VIRTUAL_ENV := $(SUB_VENV)/headless-tf21
 else
 	cd $< ; $(MAKE) patch-pix2pixhd
 	$(pip_install)


### PR DESCRIPTION
This removes the irritating situation that all executables from sub-venvs end up in /usr/local/bin whereas the others are in /usr/bin (which also makes it more difficult for dependent stages to add their scripts).