### PR TITLE
Fix build for opencv-python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ CUSTOM_DEPS += cmake gcc g++
 opencv-python: GIT_RECURSIVE = --recursive
 opencv-python/setup.py: opencv-python
 $(SHARE)/opencv-python: opencv-python/setup.py | $(ACTIVATE_VENV) $(SHARE) $(SHARE)/numpy
-	. $(ACTIVATE_VENV) && ENABLE_HEADLESS=1 $(PYTHON) $< bdist_wheel
+	. $(ACTIVATE_VENV) && cd opencv-python && ENABLE_HEADLESS=1 $(PYTHON) setup.py bdist_wheel
 	. $(ACTIVATE_VENV) && $(PIP) install $(<D)/dist/opencv_python_headless-*.whl
 	@touch $@
 $(BIN)/ocrd: $(SHARE)/opencv-python


### PR DESCRIPTION
The setup.py script fails to build opencv-python when it is run from a
different directory:

. /venv-20201008/bin/activate && ENABLE_HEADLESS=1 python3 opencv-python/setup.py bdist_wheel
Traceback (most recent call last):
  File "opencv-python/setup.py", line 448, in <module>
    main()
  File "opencv-python/setup.py", line 57, in main
    build_contrib, build_headless, is_CI_build
  File "opencv-python/setup.py", line 417, in get_and_set_info
    with open(version_file) as fp:
FileNotFoundError: [Errno 2] No such file or directory: '/ocrd_all/opencv-python/opencv-python/cv2/version.py'
Makefile:187: recipe for target '/venv-20201008/share/opencv-python' failed
make: *** [/venv-20201008/share/opencv-python] Error 1

Fix this by changing the directory before starting the script.

Signed-off-by: Stefan Weil <stefan.weil@bib.uni-mannheim.de>