### PR TITLE
Add LC_ALL, LANG, and TF_FORCE_GPU_ALLOW_GROWTH ENVs to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ ENV VIRTUAL_ENV $PREFIX
 # make apt run non-interactive during build
 ENV DEBIAN_FRONTEND noninteractive
 
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV TF_FORCE_GPU_ALLOW_GROWTH=true
+
 # make apt system functional
 RUN apt-get -y update \
  && apt-get install -y apt-utils


### PR DESCRIPTION
As discussed in https://github.com/OCR-D/ocrd_calamari/issues/46#issuecomment-711053497, the Dockerfile currently omits a number of important environmental variables: `LC_ALL`, `LANG`, and `TF_FORCE_GPU_ALLOW_GROWTH`.

## The `LC_ALL` and `LANG` environmental variables
Unless the `LC_ALL` and `LANG` environmental variables are configured on the host device to use Unicode, running Python in the produced Docker image fails with the following error:

```
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/en/7.x/python3/ for mitigation steps.

This system supports the C.UTF-8 locale which is recommended.
You might be able to resolve your issue by exporting the
following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```
This pull request overrides the values of the `LC_ALL` and `LANG` environmental variables to make the Dockerfile portable.

## The `TF_FORCE_GPU_ALLOW_GROWTH` environmental variable
Unless the `TF_FORCE_GPU_ALLOW_GROWTH` environmental variable is `true`, a single `calamari-recognize` process will consume all VRAM, although it only needs ca 4G:
```
Sat Oct 17 19:35:37 2020       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 455.23.05    Driver Version: 455.23.05    CUDA Version: 11.1     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla T4            Off  | 00000000:3F:00.0 Off |                    0 |
| N/A   50C    P0    28W /  70W |  14850MiB / 15109MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
|   1  Tesla T4            Off  | 00000000:B2:00.0 Off |                    0 |
| N/A   48C    P0    27W /  70W |    106MiB / 15109MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A      4697      C   .../headless-tf1/bin/python3    14847MiB |
|    1   N/A  N/A      4697      C   .../headless-tf1/bin/python3      103MiB |
+-----------------------------------------------------------------------------+
```
This pull request sets the value of the `TF_FORCE_GPU_ALLOW_GROWTH` environmental variable to `true` to make Tensoflow to only allocate GPU memory as needed.