### PR TITLE
adapt TESSDATA to resmgr default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -642,7 +642,9 @@ CUSTOM_DEPS += g++ make automake libleptonica-dev
 # but since we are building statically, we need more (static) libs at build time
 CUSTOM_DEPS += libarchive-dev libcurl4-nss-dev libgif-dev libjpeg-dev libpng-dev libtiff-dev
 
-TESSDATA := $(VIRTUAL_ENV)/share/tessdata
+XDG_DATA_HOME ?= $(if $(HOME),$(HOME)/.local/share,/usr/local/share)
+DEFAULT_RESLOC ?= $(XDG_DATA_HOME)/ocrd-resources
+TESSDATA ?= $(DEFAULT_RESLOC)/ocrd-tesserocr-recognize
 TESSDATA_URL := https://github.com/tesseract-ocr/tessdata_fast
 TESSERACT_TRAINEDDATA = $(ALL_TESSERACT_MODELS:%=$(TESSDATA)/%.traineddata)
 
@@ -683,7 +685,7 @@ tesseract/Makefile.in: tesseract
 TESSERACT_CONFIG ?= --disable-openmp --disable-shared CXXFLAGS="-g -O2 -fPIC"
 $(BIN)/tesseract: tesseract/Makefile.in
 	mkdir -p $(VIRTUAL_ENV)/build/tesseract
-	cd $(VIRTUAL_ENV)/build/tesseract && $(CURDIR)/tesseract/configure --prefix="$(VIRTUAL_ENV)" $(TESSERACT_CONFIG)
+	cd $(VIRTUAL_ENV)/build/tesseract && $(CURDIR)/tesseract/configure --disable-tessdata-prefix $(TESSERACT_CONFIG)
 	cd $(VIRTUAL_ENV)/build/tesseract && $(MAKE) install
 
 # Build and install Tesseract training tools.


### PR DESCRIPTION
Not sure if this is the right way to do it (`make` phase 1 cannot be used to check `ocrd bashlib constants XDG_DATA_HOME` etc, but `install` recipes already use `ocrd resmgr download`, so maybe we should _export_ `XDG_DATA_HOME` defined here...). 

But the current state is clearly broken: minimal models will only be installed into `venv/share/tessdata`, where models are usable for standalone Tesseract without `--tessdata-dir`, but not for our wrapper – it now expects them in `$XDG_DATA_HOME/ocrd-resources/ocrd-tesserocr-recognize` (and there is nothing besides setting the environment variable override `export TESSDATA_PREFIX=$VIRTUAL_ENV/share/tessdata` that could save that).