### PR TITLE
Don't disable built-in TESSDATA_PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -672,6 +672,7 @@ TESSDATA ?= $(DEFAULT_RESLOC)/ocrd-tesserocr-recognize
 TESSDATA_RELEASE = 4.1.0
 TESSDATA_URL := https://github.com/tesseract-ocr/tessdata_fast/raw/$(TESSDATA_RELEASE)
 TESSERACT_TRAINEDDATA = $(ALL_TESSERACT_MODELS:%=$(TESSDATA)/%.traineddata)
+TESSERACT_TRAINEDDATA += $(ALL_TESSERACT_MODELS:%=$(VIRTUAL_ENV)/share/tessdata/%.traineddata)
 
 stripdir = $(patsubst %/,%,$(dir $(1)))
 
@@ -692,6 +693,9 @@ $(TESSDATA)/%.traineddata:
 	$(call WGET,$@,$(TESSDATA_URL)/$(notdir $@)) || \
 	$(call WGET,$@,$(TESSDATA_URL)/$(notdir $(call stripdir,$@))/$(notdir $@)) || \
 		{ $(RM) $@; false; }
+
+$(VIRTUAL_ENV)/share/tessdata/%.traineddata: $(TESSDATA)/%.traineddata
+	cp $< $@
 
 tesseract/Makefile.in: tesseract
 	cd tesseract && ./autogen.sh

--- a/Makefile
+++ b/Makefile
@@ -697,10 +697,7 @@ tesseract/Makefile.in: tesseract
 	cd tesseract && ./autogen.sh
 
 # Build and install Tesseract.
-# We do not want to compile-in TESSDATA_PREFIX here, because our preferred TESSDATA path
-# would still get incorrectly suffixed by "/tessdata" at runtime.
-# Instead, we will rely on TESSDATA_PREFIX=$(TESSDATA) as a shell variable for the standalone CLI.
-TESSERACT_CONFIG ?= --disable-tessdata-prefix --disable-openmp --disable-shared CXXFLAGS="-g -O2 -fPIC"
+TESSERACT_CONFIG ?= --disable-openmp --disable-shared CXXFLAGS="-g -O2 -fPIC"
 $(BIN)/tesseract: tesseract/Makefile.in
 	mkdir -p $(VIRTUAL_ENV)/build/tesseract
 	cd $(VIRTUAL_ENV)/build/tesseract && $(CURDIR)/tesseract/configure --prefix="$(VIRTUAL_ENV)" $(TESSERACT_CONFIG)


### PR DESCRIPTION
This allows using the `tesseract` cli again without setting an
explicit TESSDATA_PREFIX.

Signed-off-by: Stefan Weil <sw@weilnetz.de>