### PR TITLE
Fix URLs for Tesseract downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,7 +669,8 @@ CUSTOM_DEPS += libpango1.0-dev
 XDG_DATA_HOME ?= $(if $(HOME),$(HOME)/.local/share,/usr/local/share)
 DEFAULT_RESLOC ?= $(XDG_DATA_HOME)/ocrd-resources
 TESSDATA ?= $(DEFAULT_RESLOC)/ocrd-tesserocr-recognize
-TESSDATA_URL := https://github.com/tesseract-ocr/tessdata_fast
+TESSDATA_RELEASE = 4.1.0
+TESSDATA_URL := https://github.com/tesseract-ocr/tessdata_fast/raw/$(TESSDATA_RELEASE)
 TESSERACT_TRAINEDDATA = $(ALL_TESSERACT_MODELS:%=$(TESSDATA)/%.traineddata)
 
 stripdir = $(patsubst %/,%,$(dir $(1)))
@@ -685,17 +686,11 @@ all: install-tesseract
 script/%.traineddata: $(TESSDATA)/script/%.traineddata
 	$(MAKE) $^
 
-# Special rule for equ.traineddata which is only available from tesseract-ocr/tessdata.
-$(TESSDATA)/equ.traineddata:
-	@mkdir -p $(dir $@)
-	$(call WGET,$@,https://github.com/tesseract-ocr/tessdata/raw/master/$(notdir $@)) || \
-		{ $(RM) $@; false; }
-
-# Default rule for all other traineddata models.
+# Default rule for traineddata models.
 $(TESSDATA)/%.traineddata:
 	@mkdir -p $(dir $@)
-	$(call WGET,$@,$(TESSDATA_URL)/raw/master/$(notdir $@)) || \
-	$(call WGET,$@,$(TESSDATA_URL)/raw/master/$(notdir $(call stripdir,$@))/$(notdir $@)) || \
+	$(call WGET,$@,$(TESSDATA_URL)/$(notdir $@)) || \
+	$(call WGET,$@,$(TESSDATA_URL)/$(notdir $(call stripdir,$@))/$(notdir $@)) || \
 		{ $(RM) $@; false; }
 
 tesseract/Makefile.in: tesseract


### PR DESCRIPTION
Use a well defined tagged release instead of the master branch (which
is now called main for tessdata_fast and tessdata).

The current stable release is 4.1.0.

The special exception for equ.traineddata is unnecessary with 4.1.0,
so remove it.

Signed-off-by: Stefan Weil <sw@weilnetz.de>