### PR TITLE
Add GitHub action for `make all`

### DIFF
--- a/.github/workflows/makeall-linux.yaml
+++ b/.github/workflows/makeall-linux.yaml
@@ -1,0 +1,51 @@
+# Reusable GitHub workflow for `make all` on Linux'.
+
+name: make all (Linux)
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+on:
+  workflow_call:
+    # Workflow triggered by other workflow.
+    inputs:
+      os:
+        description: 'Stringified JSON object with operating systems'
+        default: 'undefined'
+        required: false
+        type: string
+      python-version:
+        description: 'Python version'
+        default: 'undefined'
+        required: false
+        type: string
+
+jobs:
+  make:
+    #runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(inputs.os) }}
+        python-version: ${{ fromJson(inputs.python-version) }}
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON_VERSION: ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    #    architecture: x64
+    - name: Show inputs.os
+      run: echo ${{ inputs.os }}
+    - name: Show environment
+      run: echo OS=${{ env.OS }}, PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+    - name: Install dependencies
+      run: sudo make deps-ubuntu PYTHON=python${{ env.PYTHON_VERSION}}
+    - name: Make all
+      run: make all PYTHON=python${{ env.PYTHON_VERSION }}
+    - name: Run check
+      run: make check

--- a/.github/workflows/makeall.yml
+++ b/.github/workflows/makeall.yml
@@ -1,0 +1,72 @@
+# Run "make all" on selected Ubuntu and Python versions.
+
+name: make all
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+on:
+  # Trigger workflow on push event.
+  #push:
+  #   branches: [ ci ]
+
+  # Trigger workflow on pull request.
+  # pull_request:
+  #   branches: [ ci ]
+
+  # Trigger workflow in GitHub web frontend or from API.
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'Operating system'
+        required: true
+        default: any
+        type: choice
+        options:
+          - any
+          - ubuntu-18.04
+          - ubuntu-20.04
+      python-version:
+        description: 'Python version'
+        required: true
+        default: any
+        type: choice
+        options:
+          - any
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+
+jobs:
+  # Run builds for all Ubuntu and Python versions.
+  build-any:
+    # https://docs.github.com/en/actions/learn-github-actions/expressions
+    if: ${{ (github.event.inputs.os == 'any') && (github.event.inputs.python-version == 'any') || (github.event.inputs.os == '') }}
+    uses: ./.github/workflows/makeall-linux.yaml
+    with:
+      os: "[\'ubuntu-18.04\', \'ubuntu-20.04\']"
+      python-version: "['3.6', '3.7', '3.8', '3.9', '3.10']"
+
+  # Run builds for all Ubuntu versions and selected Python version.
+  build-any-os:
+    if: ${{ (github.event.inputs.os == 'any') && (github.event.inputs.python-version != 'any') }}
+    uses: ./.github/workflows/makeall-linux.yaml
+    with:
+      os: "[\'ubuntu-18.04\', \'ubuntu-20.04\']"
+      python-version: "[\'${{ github.event.inputs.python-version }}\']"
+
+  # Run builds for selected Ubuntu version and all Python versions.
+  build-any-python:
+    if: ${{ (github.event.inputs.os != 'any') && (github.event.inputs.python-version == 'any') }}
+    uses: ./.github/workflows/makeall-linux.yaml
+    with:
+      os: "[\'${{ github.event.inputs.os }}\']"
+      python-version: "['3.6', '3.7', '3.8', '3.9', '3.10']"
+
+  # Run builds for selected Ubuntu and Python versions.
+  build:
+    if: ${{ (github.event.inputs.os != 'any') && (github.event.inputs.python-version != 'any') && (github.event.inputs.os != '') }}
+    uses: ./.github/workflows/makeall-linux.yaml
+    with:
+      os: "[\'${{ github.event.inputs.os }}\']"
+      python-version: "[\'${{ github.event.inputs.python-version }}\']"


### PR DESCRIPTION
It is currently configured to be triggered manually either from the
GitHub web frontend or from the GitHub API.

`make all` can be run with a selected version of Ubuntu and Python,
or a matrix of versions.

Signed-off-by: Stefan Weil <sw@weilnetz.de>