### PR TITLE
[no ci] [RFC] Rework build process

### DIFF
--- a/.github/workflows/makeall-linux.yaml
+++ b/.github/workflows/makeall-linux.yaml
@@ -49,5 +49,7 @@ jobs:
       run: sudo make deps-ubuntu PYTHON=python${{ env.PYTHON_VERSION}}
     - name: Make all
       run: make all PYTHON=python${{ env.PYTHON_VERSION }}
+    - name: Show OCR-D modules and executables
+      run: make show PYTHON=python${{ env.PYTHON_VERSION }}
     - name: Run check
       run: make check

--- a/Makefile
+++ b/Makefile
@@ -253,9 +253,10 @@ endif
 
 ifneq ($(findstring ocrd_detectron2, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_DETECTRON2)
-OCRD_DETECTRON2 += $(BIN)/ocrd-detectron2-segment
-$(call multirule,$(OCRD_DETECTRON2)): ocrd_detectron2
-	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
+OCRD_DETECTRON2 := $(BIN)/ocrd-detectron2-segment
+$(OCRD_DETECTRON2): ocrd_detectron2
+	# . $(ACTIVATE_VENV) && $(MAKE) -C $< deps
+	. $(ACTIVATE_VENV) && cd $< && pip install 'git+https://github.com/facebookresearch/detectron2.git' && pip install -r requirements.txt
 	$(pip_install)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,11 @@ create_venv := $(shell $(PYTHON) -m venv $(VIRTUAL_ENV) && bash -c "source $(VIR
 endif
 endif
 ifeq ($(wildcard $(SUB_VENV)/headless-tf1),)
+ifeq ($(PYTHON_VERSION),3.6)
+create_venv := $(shell $(PYTHON) -m venv $(SUB_VENV)/headless-tf1 && bash -c "source $(SUB_VENV)/headless-tf1/bin/activate && curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python - && pip install -U pip setuptools wheel")
+else
 create_venv := $(shell $(PYTHON) -m venv $(SUB_VENV)/headless-tf1 && bash -c "source $(SUB_VENV)/headless-tf1/bin/activate && pip install -U pip setuptools wheel")
+endif
 endif
 #ifeq ($(wildcard $(SUB_VENV)/headless-tf21),)
 #create_venv := $(shell $(PYTHON) -m venv $(SUB_VENV)/headless-tf21 && bash -c "source $(SUB_VENV)/headless-tf21/bin/activate && pip install -U pip setuptools wheel")

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,13 @@ ACTIVATE_VENV = $(VIRTUAL_ENV)/bin/activate
 PYTHON_VERSION := $(shell $(PYTHON) -c 'import sys; print("%u.%u" % (sys.version_info.major, sys.version_info.minor))')
 
 ifeq ($(MAKECMDGOALS), all)
+CHECK_SUBENVS := true
+endif
+ifeq ($(MAKECMDGOALS), check)
+CHECK_SUBENVS := true
+endif
+
+ifdef CHECK_SUBENVS
 
 # Create all required virtual environments.
 ifeq ($(wildcard $(VIRTUAL_ENV)),)

--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,9 @@ $(OCRD_PC_SEGMENTATION): ocrd_pc_segmentation
 	$(pip_install)
 endif
 
+ifndef TENSORFLOW_2_1
+override OCRD_MODULES := $(filter-out ocrd_anybaseocr, $(OCRD_MODULES))
+endif
 ifneq ($(findstring ocrd_anybaseocr, $(OCRD_MODULES)),)
 install-models: install-models-anybaseocr
 .PHONY: install-models-anybaseocr
@@ -501,9 +504,6 @@ install-models-anybaseocr:
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-anybaseocr-layout-analysis '*'
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-anybaseocr-tiseg '*'
 
-ifndef TENSORFLOW_2_1
-override OCRD_MODULES := $(filter-out ocrd_anybaseocr, $(OCRD_MODULES))
-endif
 OCRD_EXECUTABLES += $(OCRD_ANYBASEOCR)
 OCRD_ANYBASEOCR := $(BIN)/ocrd-anybaseocr-crop
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-binarize

--- a/Makefile
+++ b/Makefile
@@ -255,15 +255,8 @@ ifneq ($(findstring ocrd_detectron2, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_DETECTRON2)
 OCRD_DETECTRON2 += $(BIN)/ocrd-detectron2-segment
 $(call multirule,$(OCRD_DETECTRON2)): ocrd_detectron2
-ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_DETECTRON2)) VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
-	$(call delegate_venv,$(OCRD_DETECTRON2),$(SUB_VENV)/headless-torch14)
-ocrd_detectron2-check:
-	$(MAKE) check OCRD_MODULES=ocrd_detectron2 VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
-else
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
 	$(pip_install)
-endif
 endif
 
 ifneq ($(findstring cor-asv-fst, $(OCRD_MODULES)),)
@@ -501,14 +494,7 @@ OCRD_EXECUTABLES += $(OCRD_TYPECLASS)
 OCRD_TYPECLASS := $(BIN)/ocrd-typegroups-classifier
 OCRD_TYPECLASS += $(BIN)/typegroups-classifier
 $(call multirule,$(OCRD_TYPECLASS)): ocrd_typegroups_classifier
-ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_TYPECLASS)) VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
-	$(call delegate_venv,$(OCRD_TYPECLASS),$(SUB_VENV)/headless-torch14)
-ocrd_typegroups_classifier-check:
-	$(MAKE) check OCRD_MODULES=ocrd_typegroups_classifier VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
-else
 	$(pip_install)
-endif
 endif
 
 ifneq ($(findstring ocrd_doxa, $(OCRD_MODULES)),)

--- a/Makefile
+++ b/Makefile
@@ -485,12 +485,22 @@ $(OCRD_CALAMARI): ocrd_calamari
 	$(pip_install)
 endif
 
+ifndef TENSORFLOW_2_1
+override OCRD_MODULES := $(filter-out ocrd_pc_segmentation, $(OCRD_MODULES))
+endif
 ifneq ($(findstring ocrd_pc_segmentation, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_PC_SEGMENTATION)
 OCRD_PC_SEGMENTATION := $(BIN)/ocrd-pc-segmentation
 $(OCRD_PC_SEGMENTATION): ocrd_pc_segmentation
+ifeq (0,$(MAKELEVEL))
+	$(MAKE) -B -o $< $(notdir $(OCRD_PC_SEGMENTATION)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
+	$(call delegate_venv,$(OCRD_PC_SEGMENTATION),$(SUB_VENV)/headless-tf2)
+ocrd_pc_segmentation-check:
+	$(MAKE) check OCRD_MODULES=ocrd_pc_segmentation VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
+else
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
 	$(pip_install)
+endif
 endif
 
 ifndef TENSORFLOW_2_1

--- a/Makefile
+++ b/Makefile
@@ -63,22 +63,15 @@ else
 create_venv := $(shell $(PYTHON) -m venv $(SUB_VENV)/headless-tf1 && bash -c "source $(SUB_VENV)/headless-tf1/bin/activate && pip install -U pip setuptools wheel")
 endif
 endif
-#ifeq ($(wildcard $(SUB_VENV)/headless-tf21),)
-#create_venv := $(shell $(PYTHON) -m venv $(SUB_VENV)/headless-tf21 && bash -c "source $(SUB_VENV)/headless-tf21/bin/activate && pip install -U pip setuptools wheel")
-#endif
 
 # Try to install different versions of Tensorflow.
 ifneq (, $(shell bash -c "source $(SUB_VENV)/headless-tf1/bin/activate && pip install tensorflow-gpu==1.15" >/dev/null 2>&1 && echo true))
 TENSORFLOW_1 := 1
 endif
-#ifneq (, $(shell bash -c "source $(SUB_VENV)/headless-tf21/bin/activate && pip install tensorflow==2.1" >/dev/null 2>&1 && echo true))
-#TENSORFLOW_2_1 := 2.1
-#endif
 
 else
 
 TENSORFLOW_1 := 1
-#TENSORFLOW_2_1 := 2.1
 
 endif
 
@@ -648,11 +641,18 @@ endif
 # install gracefully with dependencies, and finally
 # install again forcefully without depds (to ensure
 # the binary itself updates):
-ifeq ($(findstring headless-tf1, $(VIRTUAL_ENV)),)
+ifeq (0,$(MAKELEVEL))
+ifeq ($(PYTHON_VERSION),3.10)
 define pip_install
 . $(ACTIVATE_VENV) && cd $< && $(SEMPIP) pip install $(PIP_OPTIONS_E) . && touch -c $@
 endef
 else
+define pip_install
+. $(ACTIVATE_VENV) && cd $< && $(SEMPIP) pip install -c $(CURDIR)/constraints.txt $(PIP_OPTIONS_E) . && touch -c $@
+endef
+endif
+endif
+ifneq ($(findstring headless-tf1, $(VIRTUAL_ENV)),)
 define pip_install
 . $(ACTIVATE_VENV) && cd $< && $(SEMPIP) pip install -c $(CURDIR)/constraints_tf1.txt $(PIP_OPTIONS_E) . && touch -c $@
 endef

--- a/Makefile
+++ b/Makefile
@@ -727,7 +727,7 @@ CUSTOM_DEPS += automake ca-certificates g++ libtool make pkg-config
 # Required library.
 CUSTOM_DEPS += libleptonica-dev
 # Optional libraries for enhanced functionality.
-CUSTOM_DEPS += libarchive-dev libcurl4-nss-dev
+CUSTOM_DEPS += libarchive-dev libcurl4-openssl-dev
 # Optional library for training tools.
 CUSTOM_DEPS += libpango1.0-dev
 

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ OCRD_KRAKEN := $(BIN)/ocrd-kraken-binarize
 OCRD_KRAKEN += $(BIN)/ocrd-kraken-segment
 OCRD_KRAKEN += $(BIN)/ocrd-kraken-recognize
 $(call multirule,$(OCRD_KRAKEN)): ocrd_kraken $(BIN)/ocrd
+	pip install 'git+https://github.com/stweil/kraken.git'
 	$(pip_install)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-compare
 OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-repl
 $(call multirule,$(OCRD_COR_ASV_ANN)): cor-asv-ann
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_ANN)) -c constraints-tf1.txt" VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_ANN)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
 	$(call delegate_venv,$(OCRD_COR_ASV_ANN),$(SUB_VENV)/headless-tf1)
 cor-asv-ann-check:
 	$(MAKE) check OCRD_MODULES=cor-asv-ann VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
@@ -305,7 +305,7 @@ OCRD_COR_ASV_FST := $(BIN)/ocrd-cor-asv-fst-process
 OCRD_COR_ASV_FST += $(BIN)/cor-asv-fst-train
 $(call multirule,$(OCRD_COR_ASV_FST)): cor-asv-fst
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_FST)) -c constraints-tf1.txt" VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_FST)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
 	$(call delegate_venv,$(OCRD_COR_ASV_FST),$(SUB_VENV)/headless-tf1)
 cor-asv-fst-check:
 	$(MAKE) check OCRD_MODULES=cor-asv-fst VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
@@ -325,7 +325,7 @@ OCRD_KERASLM := $(BIN)/ocrd-keraslm-rate
 OCRD_KERASLM += $(BIN)/keraslm-rate
 $(call multirule,$(OCRD_KERASLM)): ocrd_keraslm
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_KERASLM)) -c constraints-tf1.txt" VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) -B -o $< $(notdir $(OCRD_KERASLM)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
 	$(call delegate_venv,$(OCRD_KERASLM),$(SUB_VENV)/headless-tf1)
 ocrd_keraslm-check:
 	$(MAKE) check OCRD_MODULES=ocrd_keraslm VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
@@ -400,7 +400,7 @@ OCRD_SEGMENT += $(BIN)/ocrd-segment-repair
 OCRD_SEGMENT += $(BIN)/ocrd-segment-project
 $(call multirule,$(OCRD_SEGMENT)): ocrd_segment
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_SEGMENT)) -c constraints-tf1.txt" VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) -B -o $< $(notdir $(OCRD_SEGMENT)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
 	$(call delegate_venv,$(OCRD_SEGMENT),$(SUB_VENV)/headless-tf1)
 ocrd_segment-check:
 	$(MAKE) check OCRD_MODULES=ocrd_segment VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
@@ -551,7 +551,7 @@ OCRD_EXECUTABLES += $(SBB_BINARIZATION)
 SBB_BINARIZATION := $(BIN)/ocrd-sbb-binarize
 $(SBB_BINARIZATION): sbb_binarization
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(SBB_BINARIZATION)) -c constraints-tf1.txt" VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) -B -o $< $(notdir $(SBB_BINARIZATION)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
 	$(call delegate_venv,$(SBB_BINARIZATION),$(SUB_VENV)/headless-tf1)
 sbb_binarization-check:
 	$(MAKE) check OCRD_MODULES=sbb_binarization VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
@@ -573,7 +573,7 @@ OCRD_EXECUTABLES += $(SBB_LINE_DETECTOR)
 SBB_LINE_DETECTOR := $(BIN)/ocrd-sbb-textline-detector
 $(SBB_LINE_DETECTOR): sbb_textline_detector
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(SBB_LINE_DETECTOR)) -c constraints-tf1.txt" VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) -B -o $< $(notdir $(SBB_LINE_DETECTOR)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
 	$(call delegate_venv,$(SBB_LINE_DETECTOR),$(SUB_VENV)/headless-tf1)
 sbb_textline_detector-check:
 	$(MAKE) check OCRD_MODULES=sbb_textline_detector VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
@@ -595,7 +595,7 @@ OCRD_EXECUTABLES += $(EYNOLLAH_SEGMENT)
 EYNOLLAH_SEGMENT := $(BIN)/ocrd-eynollah-segment
 $(EYNOLLAH_SEGMENT): eynollah
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(EYNOLLAH_SEGMENT)) -c constraints-tf1.txt" VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) -B -o $< $(notdir $(EYNOLLAH_SEGMENT)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
 	$(call delegate_venv,$(EYNOLLAH_SEGMENT),$(SUB_VENV)/headless-tf1)
 eynollah-check:
 	$(MAKE) check OCRD_MODULES=eynollah VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
@@ -634,9 +634,15 @@ endif
 # install gracefully with dependencies, and finally
 # install again forcefully without depds (to ensure
 # the binary itself updates):
+ifeq ($(findstring headless-tf1, $(VIRTUAL_ENV)),)
 define pip_install
 . $(ACTIVATE_VENV) && cd $< && $(SEMPIP) pip install $(PIP_OPTIONS_E) . && touch -c $@
 endef
+else
+define pip_install
+. $(ACTIVATE_VENV) && cd $< && $(SEMPIP) pip install -c $(CURDIR)/constraints_tf1.txt $(PIP_OPTIONS_E) . && touch -c $@
+endef
+endif
 
 # Workaround for missing prebuilt versions of TF<2 for Python==3.8
 # todo: find another solution for 3.9, 3.10 etc

--- a/Makefile
+++ b/Makefile
@@ -437,29 +437,15 @@ install-models-calamari: $(BIN)/ocrd
 OCRD_EXECUTABLES += $(OCRD_CALAMARI)
 OCRD_CALAMARI := $(BIN)/ocrd-calamari-recognize
 $(OCRD_CALAMARI): ocrd_calamari
-ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_CALAMARI)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
-	$(call delegate_venv,$(OCRD_CALAMARI),$(SUB_VENV)/headless-tf2)
-ocrd_calamari-check:
-	$(MAKE) check OCRD_EXECUTABLES=$(OCRD_CALAMARI) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
-else
 	$(pip_install)
-endif
 endif
 
 ifneq ($(findstring ocrd_pc_segmentation, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_PC_SEGMENTATION)
 OCRD_PC_SEGMENTATION := $(BIN)/ocrd-pc-segmentation
 $(OCRD_PC_SEGMENTATION): ocrd_pc_segmentation
-ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_PC_SEGMENTATION)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
-	$(call delegate_venv,$(OCRD_PC_SEGMENTATION),$(SUB_VENV)/headless-tf2)
-ocrd_pc_segmentation-check:
-	$(MAKE) check OCRD_MODULES=ocrd_pc_segmentation VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
-else
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
 	$(pip_install)
-endif
 endif
 
 ifneq ($(findstring ocrd_anybaseocr, $(OCRD_MODULES)),)

--- a/Makefile
+++ b/Makefile
@@ -302,8 +302,10 @@ ifneq ($(findstring ocrd_detectron2, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_DETECTRON2)
 OCRD_DETECTRON2 := $(BIN)/ocrd-detectron2-segment
 $(OCRD_DETECTRON2): ocrd_detectron2
-	# . $(ACTIVATE_VENV) && $(MAKE) -C $< deps
-	. $(ACTIVATE_VENV) && cd $< && pip install 'git+https://github.com/facebookresearch/detectron2.git' && pip install -r requirements.txt
+	. $(ACTIVATE_VENV) && pip install torch
+	. $(ACTIVATE_VENV) && cd $< && pip install 'git+https://github.com/facebookresearch/detectron2.git'
+	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
+	. $(ACTIVATE_VENV) && cd $< && pip install -r requirements.txt
 	$(pip_install)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -321,10 +321,10 @@ ifneq ($(findstring ocrd_detectron2, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_DETECTRON2)
 OCRD_DETECTRON2 := $(BIN)/ocrd-detectron2-segment
 $(OCRD_DETECTRON2): ocrd_detectron2
-	. $(ACTIVATE_VENV) && pip install torch
-	. $(ACTIVATE_VENV) && cd $< && pip install 'git+https://github.com/facebookresearch/detectron2.git'
+	. $(ACTIVATE_VENV) && $(SEMPIP) pip install torch
+	. $(ACTIVATE_VENV) && cd $< && $(SEMPIP) pip install 'git+https://github.com/facebookresearch/detectron2.git'
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
-	. $(ACTIVATE_VENV) && cd $< && pip install -r requirements.txt
+	. $(ACTIVATE_VENV) && cd $< && $(SEMPIP) pip install -r requirements.txt
 	$(pip_install)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ endif
 ifeq ($(MAKECMDGOALS), check)
 CHECK_SUBENVS := true
 endif
+ifeq ($(MAKECMDGOALS), show)
+CHECK_SUBENVS := true
+endif
 endif
 
 ifdef CHECK_SUBENVS
@@ -115,6 +118,16 @@ DEFAULT_DISABLED_MODULES += ocrd_cis
 DEFAULT_DISABLED_MODULES += ocrd_kraken
 # Python 3.10 does not provide tensorflow<=2.5.0,>=2.0.0 (from ocr4all-pixel-classifier==0.6.6->-r requirements.in (line 2)).
 DEFAULT_DISABLED_MODULES += ocrd_pc_segmentation
+endif
+ifndef TENSORFLOW_1
+# These modules cannot be built when tensorflow-gpu==1.15 is missing.
+DEFAULT_DISABLED_MODULES += cor-asv-ann
+DEFAULT_DISABLED_MODULES += cor-asv-fst
+DEFAULT_DISABLED_MODULES += eynollah
+DEFAULT_DISABLED_MODULES += ocrd_keraslm
+DEFAULT_DISABLED_MODULES += ocrd_segment
+DEFAULT_DISABLED_MODULES += sbb_binarization
+DEFAULT_DISABLED_MODULES += sbb_textline_detector
 endif
 DISABLED_MODULES ?= $(DEFAULT_DISABLED_MODULES)
 
@@ -282,9 +295,6 @@ $(OCRD_OCROPY): ocrd_ocropy $(BIN)/ocrd
 	$(pip_install)
 endif
 
-ifndef TENSORFLOW_1
-override OCRD_MODULES := $(filter-out cor-asv-ann, $(OCRD_MODULES))
-endif
 ifneq ($(findstring cor-asv-ann, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_COR_ASV_ANN)
 OCRD_COR_ASV_ANN := $(BIN)/ocrd-cor-asv-ann-evaluate
@@ -318,9 +328,6 @@ $(OCRD_DETECTRON2): ocrd_detectron2
 	$(pip_install)
 endif
 
-ifndef TENSORFLOW_1
-override OCRD_MODULES := $(filter-out cor-asv-fst, $(OCRD_MODULES))
-endif
 ifneq ($(findstring cor-asv-fst, $(OCRD_MODULES)),)
 deps-ubuntu-modules: cor-asv-fst
 OCRD_EXECUTABLES += $(OCRD_COR_ASV_FST)
@@ -339,9 +346,6 @@ else
 endif
 endif
 
-ifndef TENSORFLOW_1
-override OCRD_MODULES := $(filter-out ocrd_keraslm, $(OCRD_MODULES))
-endif
 ifneq ($(findstring ocrd_keraslm, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_KERASLM)
 OCRD_KERASLM := $(BIN)/ocrd-keraslm-rate
@@ -404,9 +408,6 @@ $(BIN)/ocrd-dinglehopper: dinglehopper $(BIN)/ocrd
 	$(pip_install)
 endif
 
-ifndef TENSORFLOW_1
-override OCRD_MODULES := $(filter-out ocrd_segment, $(OCRD_MODULES))
-endif
 ifneq ($(findstring ocrd_segment, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_SEGMENT)
 OCRD_SEGMENT := $(BIN)/ocrd-segment-evaluate
@@ -560,9 +561,6 @@ $(OCRD_DOXA): ocrd_doxa $(BIN)/ocrd
 	$(pip_install)
 endif
 
-ifndef TENSORFLOW_1
-override OCRD_MODULES := $(filter-out sbb_binarization, $(OCRD_MODULES))
-endif
 ifneq ($(findstring sbb_binarization, $(OCRD_MODULES)),)
 install-models: install-models-sbb-binarization
 .PHONY: install-models-sbb-binarization
@@ -583,9 +581,6 @@ else
 endif
 endif
 
-ifndef TENSORFLOW_1
-override OCRD_MODULES := $(filter-out sbb_textline_detector, $(OCRD_MODULES))
-endif
 ifneq ($(findstring sbb_textline_detector, $(OCRD_MODULES)),)
 install-models: install-models-sbb-textline
 .PHONY: install-models-sbb-textline
@@ -605,9 +600,6 @@ else
 endif
 endif
 
-ifndef TENSORFLOW_1
-override OCRD_MODULES := $(filter-out eynollah, $(OCRD_MODULES))
-endif
 ifneq ($(findstring eynollah, $(OCRD_MODULES)),)
 install-models: install-models-eynollah
 .PHONY: install-models-eynollah
@@ -757,6 +749,7 @@ $(filter-out $(BIN)/ocrd,$(OCRD_EXECUTABLES)): $(BIN)/ocrd
 all: $(OCRD_MODULES) $(OCRD_EXECUTABLES)
 show:
 	@echo VIRTUAL_ENV = $(VIRTUAL_ENV)
+	@echo DISABLED_MODULES = $(DISABLED_MODULES)
 	@echo OCRD_MODULES = $(OCRD_MODULES)
 	@echo OCRD_EXECUTABLES = $(OCRD_EXECUTABLES:$(BIN)/%=%)
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,4 @@
+# pytorch-lightning 1.6.0 requires typing-extensions>=4.0.0, but you have typing-extensions 3.7.4.3 which is incompatible.
+pytorch-lightning<1.6.0
+# ocr4all-pixel-classifier 0.6.6 requires tensorflow<=2.5.0,>=2.0.0
+tensorflow==2.5.0

--- a/constraints_tf1.txt
+++ b/constraints_tf1.txt
@@ -1,0 +1,4 @@
+# sbb-binarization 0.0.8 requires numpy<1.19.0,>=1.17.0
+numpy >= 1.17.0, < 1.19.0
+# imageio 2.16.1 requires numpy>=1.20.0 and is required by scikit-image
+imageio < 2.16

--- a/local.mk
+++ b/local.mk
@@ -1,3 +1,0 @@
-DISABLED_MODULES := cor-asv-fst opencv-python ocrd_ocropy
-# ocrd_cis uses a very old version of calamari_ocr (conflicts with ocrd_calamari).
-DISABLED_MODULES += ocrd_cis

--- a/local.mk
+++ b/local.mk
@@ -1,0 +1,3 @@
+DISABLED_MODULES := cor-asv-fst opencv-python ocrd_ocropy
+# ocrd_cis uses a very old version of calamari_ocr (conflicts with ocrd_calamari).
+DISABLED_MODULES += ocrd_cis


### PR DESCRIPTION
I currently try to rework the build process to support more modern Linux distributions and Python versions. Ideally the full test matrix of Ubuntu LTS versions and Python versions ranging from 3.6 to 3.10 should build fine.

My changes address several issues:

- Check early whether the required Tensorflow versions are available and skip those submodules which cannot be built because of missing Tensorflow.
- Use different rules for Python 3.6 and 3.10 when building `ocrd_kraken`.
- Disable `ocrd_cis` unconditionally because it requires an old `calamari_ocr` causing version conflicts.
- Address potential version conflicts for Python modules which are required by different OCR-D processors by using constraints.
- Reduce the number of sub_venvs by installing all modules which work with a recent Tensorflow in the main venv.
- Install Python module `wheel` early in all virtual environments, so it is no longer needed as a dependency.
- ... and other changes.

This PR is not for merging, but for discussion of the different aspects with the goal to find a consensus on the right solution.