### PR TITLE
Add new macro PYTHON_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,13 @@ export PKG_CONFIG_PATH
 OCRD_EXECUTABLES = $(BIN)/ocrd # add more CLIs below
 CUSTOM_DEPS = unzip wget python3-venv parallel git less # add more packages for deps-ubuntu below (or modules as preqrequisites)
 
+ifeq ($(PYTHON_VERSION),3.10)
+# Python 3.10.x does not work with current kraken.
+DISABLED_MODULES ?= cor-asv-fst opencv-python ocrd_ocropy ocrd_kraken
+else
 DISABLED_MODULES ?= cor-asv-fst opencv-python ocrd_ocropy
+endif
+
 # Default to all submodules, but allow overriding by user
 # (and treat the empty value as if it was unset)
 # opencv-python is only needed for aarch64-linux-gnu and other less common platforms,
@@ -201,10 +207,6 @@ $(SHARE)/opencv-python: opencv-python/setup.py | $(ACTIVATE_VENV) $(SHARE) $(SHA
 $(BIN)/ocrd: $(SHARE)/opencv-python
 endif
 
-ifeq ($(PYTHON_VERSION),3.10)
-# Python 3.10.x does not work with current kraken.
-override OCRD_MODULES := $(filter-out ocrd_kraken, $(OCRD_MODULES))
-endif
 ifneq ($(findstring ocrd_kraken, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_KRAKEN)
 install-models: install-models-kraken

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ BIN = $(VIRTUAL_ENV)/bin
 SHARE = $(VIRTUAL_ENV)/share
 ACTIVATE_VENV = $(VIRTUAL_ENV)/bin/activate
 
+# Get Python major and minor versions for some conditional rules.
+PYTHON_VERSION := $(shell $(PYTHON) -c 'import sys; print("%u.%u" % (sys.version_info.major, sys.version_info.minor))')
+
 define SEMGIT
 $(if $(shell sem --version 2>/dev/null),sem --will-cite --fg --id ocrd_all_git,$(error cannot find package GNU parallel))
 endef
@@ -198,6 +201,10 @@ $(SHARE)/opencv-python: opencv-python/setup.py | $(ACTIVATE_VENV) $(SHARE) $(SHA
 $(BIN)/ocrd: $(SHARE)/opencv-python
 endif
 
+ifeq ($(PYTHON_VERSION),3.10)
+# Python 3.10.x does not work with current kraken.
+override OCRD_MODULES := $(filter-out ocrd_kraken, $(OCRD_MODULES))
+endif
 ifneq ($(findstring ocrd_kraken, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_KRAKEN)
 install-models: install-models-kraken

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,12 @@ export PKG_CONFIG_PATH
 OCRD_EXECUTABLES = $(BIN)/ocrd # add more CLIs below
 CUSTOM_DEPS = unzip wget python3-venv parallel git less # add more packages for deps-ubuntu below (or modules as preqrequisites)
 
+DEFAULT_DISABLED_MODULES = cor-asv-fst opencv-python ocrd_ocropy
 ifeq ($(PYTHON_VERSION),3.10)
 # Python 3.10.x does not work with current kraken.
-DISABLED_MODULES ?= cor-asv-fst opencv-python ocrd_ocropy ocrd_kraken
-else
-DISABLED_MODULES ?= cor-asv-fst opencv-python ocrd_ocropy
+DEFAULT_DISABLED_MODULES += ocrd_kraken
 endif
+DISABLED_MODULES ?= $(DEFAULT_DISABLED_MODULES)
 
 # Default to all submodules, but allow overriding by user
 # (and treat the empty value as if it was unset)


### PR DESCRIPTION
It is used for special handling of several versions of Python,
here to disable ocrd_kraken with Python 3.10.

Signed-off-by: Stefan Weil <sw@weilnetz.de>