### PR TITLE
Update Dockerfile, Makefile and GitHub action for Docker images

### DIFF
--- a/.github/workflows/makedocker.yml
+++ b/.github/workflows/makedocker.yml
@@ -108,13 +108,13 @@ jobs:
            df -h /
     - name: Make Docker image
       run: make docker-${{ github.event.inputs.docker-image }}
-    - name: Alias Docker images
-      run: docker tag ocrd/all:${{ github.event.inputs.docker-image }} ubma/ocrd_all:${{ github.event.inputs.docker-image }}
+    # - name: Alias Docker images
+    #  run: docker tag ocrd/all:${{ github.event.inputs.docker-image }} ocrd/all:${{ github.event.inputs.docker-image }}
     - name: Show Docker images
       run: docker images
     - name: Login to Docker Hub and push images to Docker Hub
       run: |
            if ${{ github.event.inputs.upload-docker-image }}; then
-             echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-             docker push ubma/ocrd_all:${{ github.event.inputs.docker-image }}
+             echo ${{ secrets.DOCKERHUB_PASS }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+             docker push ocrd/all:${{ github.event.inputs.docker-image }}
            fi

--- a/.github/workflows/makedocker.yml
+++ b/.github/workflows/makedocker.yml
@@ -115,6 +115,6 @@ jobs:
     - name: Login to Docker Hub and push images to Docker Hub
       run: |
            if ${{ github.event.inputs.upload-docker-image }}; then
-             echo ${{ secrets.DOCKERHUB_PASS }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+             echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
              docker push ocrd/all:${{ github.event.inputs.docker-image }}
            fi

--- a/.github/workflows/makedocker.yml
+++ b/.github/workflows/makedocker.yml
@@ -63,6 +63,49 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Show Python3 version
       run: python3 --version
+    - name: Show disk usage of Homebrew, Android and .NET
+      run: sudo du -mscx /home/linuxbrew /usr/local/lib/android /usr/share/dotnet 2>/dev/null || true
+    - name: Remove Docker images
+      run: |
+           df -h
+           docker images
+           docker rmi alpine:3.12 alpine:3.13 alpine:3.14
+           docker rmi buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye
+           docker rmi debian:9 debian:10 debian:11
+           docker rmi moby/buildkit:latest
+           docker rmi node:12-alpine node:14-alpine node:16-alpine
+           docker rmi node:12 node:14 node:16
+           if false; then # don't remove Ubuntu images
+           docker rmi ubuntu:16.04 ubuntu:18.04 ubuntu:20.04
+           fi
+           docker images
+           df -h /
+    - name: Remove unneeded Debian packages
+      run: |
+           if false; then # skip time consuming package uninstall
+           sudo apt-get install -y deborphan
+           deborphan -a | sort
+           sudo apt-get purge -y $(deborphan -a|fgrep main/cli-mono|while read dummy package; do echo $package; done)
+           sudo apt-get purge -y $(deborphan -a|fgrep main/database|while read dummy package; do echo $package; done)
+           sudo apt-get purge -y $(deborphan -a|fgrep main/devel|while read dummy package; do echo $package; done)
+           sudo apt-get purge -y $(deborphan -a|fgrep main/httpd|while read dummy package; do echo $package; done)
+           sudo apt-get purge -y $(deborphan -a|fgrep main/php|while read dummy package; do echo $package; done)
+           sudo apt-get purge -y $(deborphan -a|fgrep main/vcs|while read dummy package; do echo $package; done)
+           deborphan | sort
+           sudo du -mscx /* 2>/dev/null || true
+           sudo du -mscx /opt/* 2>/dev/null || true
+           sudo du -mscx /usr/* 2>/dev/null || true
+           df -h /
+           fi
+    - name: Remove Homebrew, Android and .NET
+      run: |
+           # https://github.com/actions/virtual-environments/issues/2606#issuecomment-772683150
+           # NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+           sudo rm -rf /home/linuxbrew # will release Homebrew
+           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+           sudo du -mscx /* 2>/dev/null || true
+           df -h /
     - name: Make Docker image
       run: make docker-${{ github.event.inputs.docker-image }}
     - name: Alias Docker images

--- a/.github/workflows/makedocker.yml
+++ b/.github/workflows/makedocker.yml
@@ -1,6 +1,6 @@
-# GitHub workflow for `make docker-maximum-cuda`.
+# GitHub workflow for `make docker-*`.
 
-name: make docker-maximum-cuda
+name: make docker
 
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 on:
@@ -10,27 +10,68 @@ on:
       os:
         description: 'Operating system'
         required: true
-        default: any
+        default: 'ubuntu-18.04'
         type: choice
         options:
-          - ubuntu-18.04
-          - ubuntu-20.04
+          - 'ubuntu-18.04'
+          - 'ubuntu-20.04'
+      python-version:
+        description: 'Python version'
+        required: true
+        default: '3.6'
+        type: choice
+        options:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+      docker-image:
+        description: 'Docker image'
+        required: true
+        default: 'docker-minimum'
+        type: choice
+        options:
+          - 'minimum'
+          - 'minimum-cuda'
+          - 'medium'
+          - 'medium-cuda'
+          - 'maximum'
+          - 'maximum-cuda'
+          - 'minimum-git'
+          - 'minimum-cuda-git'
+          - 'medium-git'
+          - 'medium-cuda-git'
+          - 'maximum-git'
+          - 'maximum-cuda-git'
+      upload-docker-image:
+        description: 'Upload Docker image'
+        default: False
+        type: boolean
 
 jobs:
   make:
     runs-on: ${{ github.event.inputs.os }}
 
     env:
-      PYTHON_VERSION: '3.7'
+      PYTHON_VERSION: ${{ github.event.inputs.python-version }}
 
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-    - name: update apt repositories
-      run: sudo apt-get update
-    - name: Install dependencies
-      run: sudo make deps-ubuntu PYTHON=python${{ env.PYTHON_VERSION}}
-    - name: Make docker-maximum-cuda
-      run: make docker-maximum-cuda PYTHON=python${{ env.PYTHON_VERSION }}
+    - name: Show Python3 version
+      run: python3 --version
+    - name: Make Docker image
+      run: make docker-${{ github.event.inputs.docker-image }}
+    - name: Alias Docker images
+      run: docker tag ocrd/all:${{ github.event.inputs.docker-image }} ubma/ocrd_all:${{ github.event.inputs.docker-image }}
+    - name: Show Docker images
+      run: docker images
+    - name: Login to Docker Hub and push images to Docker Hub
+      run: |
+           if ${{ github.event.inputs.upload-docker-image }}; then
+             echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+             docker push ubma/ocrd_all:${{ github.event.inputs.docker-image }}
+           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ LABEL \
 
 # simulate a virtual env for the makefile,
 # coinciding with the Python system prefix
-ENV PREFIX=/usr
+ENV PREFIX=/usr/local
 ENV VIRTUAL_ENV $PREFIX
 # avoid HOME/.local/share (hard to predict USER here)
 # so let XDG_DATA_HOME coincide with fixed system location
@@ -80,6 +80,9 @@ RUN echo "Acquire::ftp::Timeout \"3000\";" >> /etc/apt/apt.conf.d/99network
 
 WORKDIR /build
 
+# create virtual environment
+RUN rm /usr/local/bin/pip* && apt-get purge -y python3-pip && python3 -m venv /usr/local && python3 -m pip install --force pip
+
 # copy (sub)module directories to build
 # (ADD/COPY cannot copy a list of directories,
 #  so we must rely on .dockerignore here)
@@ -95,8 +98,8 @@ RUN apt-get -y update && apt-get install -y apt-utils
 RUN echo "set -ex" > docker.sh
 # get packages for build
 RUN echo "apt-get -y install automake autoconf libtool pkg-config g++" >> docker.sh
-# we want to use PREFIX as "venv", so we need activate (as no-op)
-RUN echo "> $PREFIX/bin/activate" >> docker.sh
+RUN echo "source $PREFIX/bin/activate" >> docker.sh
+RUN echo "pip install -U pip setuptools wheel" >> docker.sh
 # try to fetch all modules system requirements
 RUN echo "make deps-ubuntu" >> docker.sh
 # build/install all tools of the requested modules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,20 +94,18 @@ RUN git submodule deinit opencv-python && git submodule foreach --recursive git 
 # make apt system functional
 RUN apt-get -y update && apt-get install -y apt-utils
 
+# get packages for build, try to fetch all modules system requirements,
+# remove unneeded automatic deps and clear pkg cache
+RUN apt-get -y install automake autoconf libtool pkg-config g++ && make deps-ubuntu && apt-get -y autoremove && apt-get clean
+
 # start a shell script (so we can comment individual steps here)
 RUN echo "set -ex" > docker.sh
-# get packages for build
-RUN echo "apt-get -y install automake autoconf libtool pkg-config g++" >> docker.sh
 RUN echo "source $PREFIX/bin/activate" >> docker.sh
 RUN echo "pip install -U pip setuptools wheel" >> docker.sh
-# try to fetch all modules system requirements
-RUN echo "make deps-ubuntu" >> docker.sh
 # build/install all tools of the requested modules:
 RUN echo "make $PARALLEL all" >> docker.sh
 # check installation
 RUN echo "make -j check CHECK_HELP=1" >> docker.sh
-# remove unneeded automatic deps and clear pkg cache
-RUN echo "apt-get -y autoremove && apt-get clean" >> docker.sh
 # remove source directories from image, unless using editable mode
 # (in the latter case, the git repos are also the installation targets
 #  and must be kept; so merely clean-up some temporary files)

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ WORKDIR /build
 #  so we must rely on .dockerignore here)
 COPY . .
 
+# deinit opencv-python (otherwise git submodule status can segfault) and remove copied junk
+RUN git submodule deinit opencv-python && git submodule foreach --recursive git clean -fxd
+
 # make apt system functional
 RUN apt-get -y update && apt-get install -y apt-utils
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN echo "make -j check CHECK_HELP=1" >> docker.sh
 # remove source directories from image, unless using editable mode
 # (in the latter case, the git repos are also the installation targets
 #  and must be kept; so merely clean-up some temporary files)
-RUN echo "if [[ '${PIP_OPTIONS}' =~ -e|--editable ]]; then make -i clean-olena clean-tesseract; else rm -fr /build; fi" >> docker.sh
+RUN echo "if [[ '${PIP_OPTIONS}' =~ -e|--editable ]]; then make -i clean-olena clean-tesseract; else rm -fr /.cache /build; fi" >> docker.sh
 # run the script in one layer/step (to minimise image size)
 # (and export all variables)
 RUN set -a; bash docker.sh

--- a/Makefile
+++ b/Makefile
@@ -840,9 +840,12 @@ ifneq ($(suffix $(PYTHON)),)
 	apt-get install -y --no-install-recommends $(notdir $(PYTHON))-dev $(notdir $(PYTHON))-venv
 endif
 	$(MAKE) deps-ubuntu-modules
-	chown -R --reference=$(CURDIR) .git $(OCRD_MODULES)
+	# Fix ownership of new/modified files and directories because
+	# deps-ubuntu is run as root, but not in a Docker build were
+	# it is not needed and costs a lot of time.
+	test "$$HOME" == "/" || chown -R --reference=$(CURDIR) .git $(OCRD_MODULES)
 # prevent the sem commands during above module updates from imposing sudo perms on HOME:
-	chown -R --reference=$(HOME) $(HOME)/.parallel
+	test "$$HOME" == "/" || chown -R --reference=$(HOME) $(HOME)/.parallel
 
 deps-ubuntu-modules:
 	set -e; for dir in $^; do $(MAKE) -C $$dir deps-ubuntu PYTHON=$(PYTHON); done

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ ALL_TESSERACT_MODELS = eng equ osd $(TESSERACT_MODELS)
 export VIRTUAL_ENV ?= $(CURDIR)/venv
 ifeq (0, $(MAKELEVEL))
 SUB_VENV = $(VIRTUAL_ENV)/sub-venv
+SUB_VENV_TF1 = $(SUB_VENV)/headless-tf1
+SUB_VENV_TF2 = $(SUB_VENV)/headless-tf2
+SUB_VENV_TORCH14 = $(SUB_VENV)/headless-torch14
+else
+SUB_VENV_TF1 = $(VIRTUAL_ENV)
+SUB_VENV_TF2 = $(VIRTUAL_ENV)
+SUB_VENV_TORCH14 = $(VIRTUAL_ENV)
 endif
 
 BIN = $(VIRTUAL_ENV)/bin
@@ -158,8 +165,9 @@ deinit:
 $(BIN)/pip: $(ACTIVATE_VENV)
 	. $(ACTIVATE_VENV) && $(SEMPIP) pip install --upgrade pip setuptools
 
-$(ACTIVATE_VENV) $(VIRTUAL_ENV):
-	$(SEMPIP) $(PYTHON) -m venv $(VIRTUAL_ENV)
+%/bin/activate:
+	$(PYTHON) -m venv $(subst /bin/activate,,$@)
+	. $@ && pip install --upgrade pip setuptools wheel
 
 .PHONY: wheel
 wheel: $(BIN)/wheel
@@ -239,12 +247,12 @@ OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-proc
 OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-eval
 OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-compare
 OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-repl
-$(call multirule,$(OCRD_COR_ASV_ANN)): cor-asv-ann
+$(call multirule,$(OCRD_COR_ASV_ANN)): cor-asv-ann $(SUB_VENV_TF1)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_ANN)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
-	$(call delegate_venv,$(OCRD_COR_ASV_ANN),$(SUB_VENV)/headless-tf1)
+	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_ANN)) VIRTUAL_ENV=$(SUB_VENV_TF1)
+	$(call delegate_venv,$(OCRD_COR_ASV_ANN),$(SUB_VENV_TF1))
 cor-asv-ann-check:
-	$(MAKE) check OCRD_MODULES=cor-asv-ann VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) check OCRD_MODULES=cor-asv-ann VIRTUAL_ENV=$(SUB_VENV_TF1)
 else
 	$(pip_install_tf1nvidia)
 	$(pip_install)
@@ -254,12 +262,12 @@ endif
 ifneq ($(findstring ocrd_detectron2, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_DETECTRON2)
 OCRD_DETECTRON2 += $(BIN)/ocrd-detectron2-segment
-$(call multirule,$(OCRD_DETECTRON2)): ocrd_detectron2
+$(call multirule,$(OCRD_DETECTRON2)): ocrd_detectron2 $(SUB_VENV_TORCH14)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_DETECTRON2)) VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
-	$(call delegate_venv,$(OCRD_DETECTRON2),$(SUB_VENV)/headless-torch14)
+	$(MAKE) -B -o $< $(notdir $(OCRD_DETECTRON2)) VIRTUAL_ENV=$(SUB_VENV_TORCH14)
+	$(call delegate_venv,$(OCRD_DETECTRON2),$(SUB_VENV_TORCH14))
 ocrd_detectron2-check:
-	$(MAKE) check OCRD_MODULES=ocrd_detectron2 VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
+	$(MAKE) check OCRD_MODULES=ocrd_detectron2 VIRTUAL_ENV=$(SUB_VENV_TORCH14)
 else
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
 	$(pip_install)
@@ -271,12 +279,12 @@ deps-ubuntu-modules: cor-asv-fst
 OCRD_EXECUTABLES += $(OCRD_COR_ASV_FST)
 OCRD_COR_ASV_FST := $(BIN)/ocrd-cor-asv-fst-process
 OCRD_COR_ASV_FST += $(BIN)/cor-asv-fst-train
-$(call multirule,$(OCRD_COR_ASV_FST)): cor-asv-fst
+$(call multirule,$(OCRD_COR_ASV_FST)): cor-asv-fst $(SUB_VENV_TF1)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_FST)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
-	$(call delegate_venv,$(OCRD_COR_ASV_FST),$(SUB_VENV)/headless-tf1)
+	$(MAKE) -B -o $< $(notdir $(OCRD_COR_ASV_FST)) VIRTUAL_ENV=$(SUB_VENV_TF1)
+	$(call delegate_venv,$(OCRD_COR_ASV_FST),$(SUB_VENV_TF1))
 cor-asv-fst-check:
-	$(MAKE) check OCRD_MODULES=cor-asv-fst VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) check OCRD_MODULES=cor-asv-fst VIRTUAL_ENV=$(SUB_VENV_TF1)
 else
 	$(pip_install_tf1nvidia)
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
@@ -288,12 +296,12 @@ ifneq ($(findstring ocrd_keraslm, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_KERASLM)
 OCRD_KERASLM := $(BIN)/ocrd-keraslm-rate
 OCRD_KERASLM += $(BIN)/keraslm-rate
-$(call multirule,$(OCRD_KERASLM)): ocrd_keraslm
+$(call multirule,$(OCRD_KERASLM)): ocrd_keraslm $(SUB_VENV_TF1)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_KERASLM)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
-	$(call delegate_venv,$(OCRD_KERASLM),$(SUB_VENV)/headless-tf1)
+	$(MAKE) -B -o $< $(notdir $(OCRD_KERASLM)) VIRTUAL_ENV=$(SUB_VENV_TF1)
+	$(call delegate_venv,$(OCRD_KERASLM),$(SUB_VENV_TF1))
 ocrd_keraslm-check:
-	$(MAKE) check OCRD_MODULES=ocrd_keraslm VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) check OCRD_MODULES=ocrd_keraslm VIRTUAL_ENV=$(SUB_VENV_TF1)
 else
 	$(pip_install_tf1nvidia)
 	$(pip_install)
@@ -360,12 +368,12 @@ OCRD_SEGMENT += $(BIN)/ocrd-segment-replace-original
 OCRD_SEGMENT += $(BIN)/ocrd-segment-replace-page
 OCRD_SEGMENT += $(BIN)/ocrd-segment-repair
 OCRD_SEGMENT += $(BIN)/ocrd-segment-project
-$(call multirule,$(OCRD_SEGMENT)): ocrd_segment
+$(call multirule,$(OCRD_SEGMENT)): ocrd_segment $(SUB_VENV_TF1)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_SEGMENT)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
-	$(call delegate_venv,$(OCRD_SEGMENT),$(SUB_VENV)/headless-tf1)
+	$(MAKE) -B -o $< $(notdir $(OCRD_SEGMENT)) VIRTUAL_ENV=$(SUB_VENV_TF1)
+	$(call delegate_venv,$(OCRD_SEGMENT),$(SUB_VENV_TF1))
 ocrd_segment-check:
-	$(MAKE) check OCRD_MODULES=ocrd_segment VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) check OCRD_MODULES=ocrd_segment VIRTUAL_ENV=$(SUB_VENV_TF1)
 else
 	$(pip_install_tf1nvidia)
 	$(pip_install)
@@ -443,12 +451,12 @@ install-models-calamari: $(BIN)/ocrd
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-calamari-recognize '*'
 OCRD_EXECUTABLES += $(OCRD_CALAMARI)
 OCRD_CALAMARI := $(BIN)/ocrd-calamari-recognize
-$(OCRD_CALAMARI): ocrd_calamari
+$(OCRD_CALAMARI): ocrd_calamari $(SUB_VENV_TF2)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_CALAMARI)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
-	$(call delegate_venv,$(OCRD_CALAMARI),$(SUB_VENV)/headless-tf2)
+	$(MAKE) -B -o $< $(notdir $(OCRD_CALAMARI)) VIRTUAL_ENV=$(SUB_VENV_TF2)
+	$(call delegate_venv,$(OCRD_CALAMARI),$(SUB_VENV_TF2))
 ocrd_calamari-check:
-	$(MAKE) check OCRD_EXECUTABLES=$(OCRD_CALAMARI) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
+	$(MAKE) check OCRD_EXECUTABLES=$(OCRD_CALAMARI) VIRTUAL_ENV=$(SUB_VENV_TF2)
 else
 	$(pip_install)
 endif
@@ -457,12 +465,12 @@ endif
 ifneq ($(findstring ocrd_pc_segmentation, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_PC_SEGMENTATION)
 OCRD_PC_SEGMENTATION := $(BIN)/ocrd-pc-segmentation
-$(OCRD_PC_SEGMENTATION): ocrd_pc_segmentation
+$(OCRD_PC_SEGMENTATION): ocrd_pc_segmentation $(SUB_VENV_TF2)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_PC_SEGMENTATION)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
-	$(call delegate_venv,$(OCRD_PC_SEGMENTATION),$(SUB_VENV)/headless-tf2)
+	$(MAKE) -B -o $< $(notdir $(OCRD_PC_SEGMENTATION)) VIRTUAL_ENV=$(SUB_VENV_TF2)
+	$(call delegate_venv,$(OCRD_PC_SEGMENTATION),$(SUB_VENV_TF2))
 ocrd_pc_segmentation-check:
-	$(MAKE) check OCRD_MODULES=ocrd_pc_segmentation VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
+	$(MAKE) check OCRD_MODULES=ocrd_pc_segmentation VIRTUAL_ENV=$(SUB_VENV_TF2)
 else
 	. $(ACTIVATE_VENV) && $(MAKE) -C $< deps
 	$(pip_install)
@@ -485,12 +493,12 @@ OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-dewarp
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-tiseg
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-textline
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-layout-analysis
-$(call multirule,$(OCRD_ANYBASEOCR)): ocrd_anybaseocr
+$(call multirule,$(OCRD_ANYBASEOCR)): ocrd_anybaseocr $(SUB_VENV_TF2)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_ANYBASEOCR)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
-	$(call delegate_venv,$(OCRD_ANYBASEOCR),$(SUB_VENV)/headless-tf2)
+	$(MAKE) -B -o $< $(notdir $(OCRD_ANYBASEOCR)) VIRTUAL_ENV=$(SUB_VENV_TF2)
+	$(call delegate_venv,$(OCRD_ANYBASEOCR),$(SUB_VENV_TF2))
 ocrd_anybaseocr-check:
-	$(MAKE) check OCRD_MODULES=ocrd_anybaseocr VIRTUAL_ENV=$(SUB_VENV)/headless-tf2
+	$(MAKE) check OCRD_MODULES=ocrd_anybaseocr VIRTUAL_ENV=$(SUB_VENV_TF2)
 else
 	$(pip_install)
 endif
@@ -500,12 +508,12 @@ ifneq ($(findstring ocrd_typegroups_classifier, $(OCRD_MODULES)),)
 OCRD_EXECUTABLES += $(OCRD_TYPECLASS)
 OCRD_TYPECLASS := $(BIN)/ocrd-typegroups-classifier
 OCRD_TYPECLASS += $(BIN)/typegroups-classifier
-$(call multirule,$(OCRD_TYPECLASS)): ocrd_typegroups_classifier
+$(call multirule,$(OCRD_TYPECLASS)): ocrd_typegroups_classifier $(SUB_VENV_TORCH14)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(OCRD_TYPECLASS)) VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
-	$(call delegate_venv,$(OCRD_TYPECLASS),$(SUB_VENV)/headless-torch14)
+	$(MAKE) -B -o $< $(notdir $(OCRD_TYPECLASS)) VIRTUAL_ENV=$(SUB_VENV_TORCH14)
+	$(call delegate_venv,$(OCRD_TYPECLASS),$(SUB_VENV_TORCH14))
 ocrd_typegroups_classifier-check:
-	$(MAKE) check OCRD_MODULES=ocrd_typegroups_classifier VIRTUAL_ENV=$(SUB_VENV)/headless-torch14
+	$(MAKE) check OCRD_MODULES=ocrd_typegroups_classifier VIRTUAL_ENV=$(SUB_VENV_TORCH14)
 else
 	$(pip_install)
 endif
@@ -526,12 +534,12 @@ install-models-sbb-binarization:
 
 OCRD_EXECUTABLES += $(SBB_BINARIZATION)
 SBB_BINARIZATION := $(BIN)/ocrd-sbb-binarize
-$(SBB_BINARIZATION): sbb_binarization
+$(SBB_BINARIZATION): sbb_binarization $(SUB_VENV_TF1)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(SBB_BINARIZATION)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
-	$(call delegate_venv,$(SBB_BINARIZATION),$(SUB_VENV)/headless-tf1)
+	$(MAKE) -B -o $< $(notdir $(SBB_BINARIZATION)) VIRTUAL_ENV=$(SUB_VENV_TF1)
+	$(call delegate_venv,$(SBB_BINARIZATION),$(SUB_VENV_TF1))
 sbb_binarization-check:
-	$(MAKE) check OCRD_MODULES=sbb_binarization VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) check OCRD_MODULES=sbb_binarization VIRTUAL_ENV=$(SUB_VENV_TF1)
 else
 	$(pip_install_tf1nvidia)
 	$(pip_install)
@@ -545,12 +553,12 @@ install-models-sbb-textline:
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-sbb-textline-detector '*'
 OCRD_EXECUTABLES += $(SBB_LINE_DETECTOR)
 SBB_LINE_DETECTOR := $(BIN)/ocrd-sbb-textline-detector
-$(SBB_LINE_DETECTOR): sbb_textline_detector
+$(SBB_LINE_DETECTOR): sbb_textline_detector $(SUB_VENV_TF1)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(SBB_LINE_DETECTOR)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
-	$(call delegate_venv,$(SBB_LINE_DETECTOR),$(SUB_VENV)/headless-tf1)
+	$(MAKE) -B -o $< $(notdir $(SBB_LINE_DETECTOR)) VIRTUAL_ENV=$(SUB_VENV_TF1)
+	$(call delegate_venv,$(SBB_LINE_DETECTOR),$(SUB_VENV_TF1))
 sbb_textline_detector-check:
-	$(MAKE) check OCRD_MODULES=sbb_textline_detector VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) check OCRD_MODULES=sbb_textline_detector VIRTUAL_ENV=$(SUB_VENV_TF1)
 else
 	$(pip_install_tf1nvidia)
 	$(pip_install)
@@ -564,12 +572,12 @@ install-models-eynollah:
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-eynollah-segment '*'
 OCRD_EXECUTABLES += $(EYNOLLAH_SEGMENT)
 EYNOLLAH_SEGMENT := $(BIN)/ocrd-eynollah-segment
-$(EYNOLLAH_SEGMENT): eynollah
+$(EYNOLLAH_SEGMENT): eynollah $(SUB_VENV_TF1)/bin/activate
 ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(EYNOLLAH_SEGMENT)) VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
-	$(call delegate_venv,$(EYNOLLAH_SEGMENT),$(SUB_VENV)/headless-tf1)
+	$(MAKE) -B -o $< $(notdir $(EYNOLLAH_SEGMENT)) VIRTUAL_ENV=$(SUB_VENV_TF1)
+	$(call delegate_venv,$(EYNOLLAH_SEGMENT),$(SUB_VENV_TF1))
 eynollah-check:
-	$(MAKE) check OCRD_MODULES=eynollah VIRTUAL_ENV=$(SUB_VENV)/headless-tf1
+	$(MAKE) check OCRD_MODULES=eynollah VIRTUAL_ENV=$(SUB_VENV_TF1)
 else
 	$(pip_install_tf1nvidia)
 	$(pip_install)
@@ -635,8 +643,8 @@ endef
 # pattern for recursive make:
 # $(executables...): module...
 # ifeq (0,$(MAKELEVEL))
-# 	$(MAKE) -B -o $< $(notdir $(executables...)) VIRTUAL_ENV=$(SUB_VENV)/name
-# 	$(call delegate_venv,$(executables...),$(SUB_VENV)/name)
+# 	$(MAKE) -B -o $< $(notdir $(executables...)) VIRTUAL_ENV=$(SUB_VENV_name)
+# 	$(call delegate_venv,$(executables...),$(SUB_VENV_name))
 # else
 # 	actual recipe...
 # fi
@@ -884,7 +892,6 @@ docker%: Dockerfile $(DOCKER_MODULES)
 	--build-arg PYTHON="$(PYTHON)" \
 	--network=host \
 	-t $(DOCKER_TAG):$(or $(*:-%=%),latest) .
-
 
 docker: DOCKER_MODULES ?= $(OCRD_MODULES)
 docker: DOCKER_PARALLEL ?= -j1

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 BIN = $(VIRTUAL_ENV)/bin
 SHARE = $(VIRTUAL_ENV)/share
-ACTIVATE_VENV = $(VIRTUAL_ENV)/bin/activate
+ACTIVATE_VENV = $(BIN)/activate
 
 # Get Python major and minor versions for some conditional rules.
 PYTHON_VERSION := $(shell $(PYTHON) -c 'import sys; print("%u.%u" % (sys.version_info.major, sys.version_info.minor))')
@@ -155,7 +155,7 @@ deinit:
 
 # Get Python modules.
 
-$(VIRTUAL_ENV)/bin/pip: $(ACTIVATE_VENV)
+$(BIN)/pip: $(ACTIVATE_VENV)
 	. $(ACTIVATE_VENV) && $(SEMPIP) pip install --upgrade pip setuptools
 
 $(ACTIVATE_VENV) $(VIRTUAL_ENV):
@@ -690,7 +690,7 @@ $(SHARE):
 	@mkdir -p "$@"
 
 # At last, add venv dependency (must not become first):
-$(OCRD_EXECUTABLES) $(BIN)/wheel: | $(VIRTUAL_ENV)/bin/pip
+$(OCRD_EXECUTABLES) $(BIN)/wheel: | $(BIN)/pip
 $(OCRD_EXECUTABLES): | $(BIN)/wheel
 # Also, add core dependency (but in a non-circular way):
 $(filter-out $(BIN)/ocrd,$(OCRD_EXECUTABLES)): $(BIN)/ocrd


### PR DESCRIPTION
The new GitHub action currently allows maintainers to select git branch, Ubuntu version, Python version, docker image variant and upload to docker.io yes/no when it is run on demand.

By default it builds the `minimum` docker image on Ubuntu 18.04 with Python 3.6 and does not upload to docker.io.