### PR TITLE
Remove sbb-textline-detector

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,9 +61,6 @@
 [submodule "workflow-configuration"]
 	path = workflow-configuration
 	url = https://github.com/bertsky/workflow-configuration.git
-[submodule "sbb_textline_detector"]
-	path = sbb_textline_detector
-	url = https://github.com/qurator-spk/sbb_textline_detector.git
 [submodule "ocrd_repair_inconsistencies"]
 	path = ocrd_repair_inconsistencies
 	url = https://github.com/qurator-spk/ocrd_repair_inconsistencies.git

--- a/Makefile
+++ b/Makefile
@@ -546,25 +546,6 @@ else
 endif
 endif
 
-ifneq ($(findstring sbb_textline_detector, $(OCRD_MODULES)),)
-install-models: install-models-sbb-textline
-.PHONY: install-models-sbb-textline
-install-models-sbb-textline:
-	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-sbb-textline-detector '*'
-OCRD_EXECUTABLES += $(SBB_LINE_DETECTOR)
-SBB_LINE_DETECTOR := $(BIN)/ocrd-sbb-textline-detector
-$(SBB_LINE_DETECTOR): sbb_textline_detector $(SUB_VENV_TF1)/bin/activate
-ifeq (0,$(MAKELEVEL))
-	$(MAKE) -B -o $< $(notdir $(SBB_LINE_DETECTOR)) VIRTUAL_ENV=$(SUB_VENV_TF1)
-	$(call delegate_venv,$(SBB_LINE_DETECTOR),$(SUB_VENV_TF1))
-sbb_textline_detector-check:
-	$(MAKE) check OCRD_MODULES=sbb_textline_detector VIRTUAL_ENV=$(SUB_VENV_TF1)
-else
-	$(pip_install_tf1nvidia)
-	$(pip_install)
-endif
-endif
-
 ifneq ($(findstring eynollah, $(OCRD_MODULES)),)
 install-models: install-models-eynollah
 .PHONY: install-models-eynollah

--- a/README.md
+++ b/README.md
@@ -343,7 +343,6 @@ This table lists which tag contains which module:
 | ocrd_pc_segmentation        | -         | -        | ☑         |
 | ocrd_typegroups_classifier  | -         | -        | ☑         |
 | sbb_binarization            | -         | -        | ☑         |
-| sbb_textline_detector       | -         | -        | ☑         |
 | cor-asv-fst                 | -         | -        | -         |
 
 **Note**: The following modules have been disabled by default and can only be
@@ -391,7 +390,7 @@ Modules may require mutually exclusive sets of dependent packages.
 
 - Tensorflow:
    * version 2 (required by ocrd_calamari, ocrd_anybaseocr and ocrd_pc_segmentation)
-   * version 1 (required by cor-asv-ann, ocrd_keraslm and sbb_textline_detector)
+   * version 1 (required by cor-asv-ann and ocrd_keraslm)
    
    The temporary solution is to require different package names:
    - `tensorflow>=2`


### PR DESCRIPTION
I suggest removing the now obsolete `sbb-textline-detector` (superseded by `Eynollah` which is already part of `ocrd_all`). 

I hope I have caught all places.