### PR TITLE
Disable modules which require old tensorflow-gpu unless it is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ OCRD_EXECUTABLES = $(BIN)/ocrd # add more CLIs below
 CUSTOM_DEPS = unzip wget python3-venv parallel git less # add more packages for deps-ubuntu below (or modules as preqrequisites)
 
 DEFAULT_DISABLED_MODULES = cor-asv-fst opencv-python ocrd_ocropy ocrd_pc_segmentation
+ifneq ($(PYTHON_VERSION),3.6)
+ifneq ($(PYTHON_VERSION),3.7)
+ifneq ($(PYTHON_VERSION),3.8)
+# Disable modules which require tensorflow-gpu 1.15 unless running a Python version which provides it.
+DEFAULT_DISABLED_MODULES += cor-asv-ann ocrd_keraslm
+endif
+endif
+endif
 ifeq ($(PYTHON_VERSION),3.10)
 # Python 3.10.x does not work with current kraken.
 DEFAULT_DISABLED_MODULES += ocrd_kraken


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>