### PR TITLE
Don't try running unavailable Python 3.6 on Ubuntu 22.04

### DIFF
--- a/.github/workflows/makeall-linux.yaml
+++ b/.github/workflows/makeall-linux.yaml
@@ -20,6 +20,9 @@ on:
 
 jobs:
   make:
+    # Don't run unsupported Ubuntu 22.04 with Python 3.6.
+    if: ${{ (fromJson(inputs.os) != 'ubuntu-22.04') || (inputs.python-version != '3.6') }}
+
     #runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>