### PR TITLE
tessdata: only use prefix/module dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,6 @@ Variables:
 	PIP_OPTIONS: extra options for the `pip install` command like `-q` or `-v` or `-e`
 	TESSERACT_MODELS: list of additional models/languages to download for Tesseract. Default: "$(ALL_TESSERACT_MODELS)"
 	TESSERACT_CONFIG: command line options for Tesseract `configure`. Default: "$(TESSERACT_CONFIG)"
-	TESSDATA: directory path where to install Tesseract models. Default (based on XDG_DATA_HOME): "$(TESSDATA)"
 EOF
 endef
 export HELP
@@ -253,6 +252,8 @@ OCRD_EXECUTABLES += $(OCRD_COR_ASV_ANN)
 OCRD_COR_ASV_ANN := $(BIN)/ocrd-cor-asv-ann-evaluate
 OCRD_COR_ASV_ANN += $(BIN)/ocrd-cor-asv-ann-process
 OCRD_COR_ASV_ANN += $(BIN)/ocrd-cor-asv-ann-align
+OCRD_COR_ASV_ANN += $(BIN)/ocrd-cor-asv-ann-join
+OCRD_COR_ASV_ANN += $(BIN)/ocrd-cor-asv-ann-mark
 OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-train
 OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-proc
 OCRD_COR_ASV_ANN += $(BIN)/cor-asv-ann-eval
@@ -411,6 +412,7 @@ OCRD_TESSEROCR := $(BIN)/ocrd-tesserocr-binarize
 OCRD_TESSEROCR += $(BIN)/ocrd-tesserocr-crop
 OCRD_TESSEROCR += $(BIN)/ocrd-tesserocr-deskew
 OCRD_TESSEROCR += $(BIN)/ocrd-tesserocr-recognize
+OCRD_TESSEROCR += $(BIN)/ocrd-tesserocr-segment
 OCRD_TESSEROCR += $(BIN)/ocrd-tesserocr-segment-line
 OCRD_TESSEROCR += $(BIN)/ocrd-tesserocr-segment-region
 OCRD_TESSEROCR += $(BIN)/ocrd-tesserocr-segment-word
@@ -517,6 +519,7 @@ install-models-sbb-binarization:
 
 OCRD_EXECUTABLES += $(SBB_BINARIZATION)
 SBB_BINARIZATION := $(BIN)/ocrd-sbb-binarize
+SBB_BINARIZATION += $(BIN)/sbb_binarize
 $(SBB_BINARIZATION): sbb_binarization
 	$(pip_install)
 endif
@@ -528,6 +531,7 @@ install-models-eynollah:
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-eynollah-segment '*'
 OCRD_EXECUTABLES += $(EYNOLLAH_SEGMENT)
 EYNOLLAH_SEGMENT := $(BIN)/ocrd-eynollah-segment
+EYNOLLAH_SEGMENT += $(BIN)/eynollah
 $(EYNOLLAH_SEGMENT): eynollah
 	$(pip_install)
 endif
@@ -689,11 +693,10 @@ CUSTOM_DEPS += libpango1.0-dev
 
 XDG_DATA_HOME ?= $(if $(HOME),$(HOME)/.local/share,/usr/local/share)
 DEFAULT_RESLOC ?= $(XDG_DATA_HOME)/ocrd-resources
-TESSDATA ?= $(DEFAULT_RESLOC)/ocrd-tesserocr-recognize
+TESSDATA = $(VIRTUAL_ENV)/share/tessdata/
 TESSDATA_RELEASE = 4.1.0
 TESSDATA_URL := https://github.com/tesseract-ocr/tessdata_fast/raw/$(TESSDATA_RELEASE)
 TESSERACT_TRAINEDDATA = $(ALL_TESSERACT_MODELS:%=$(TESSDATA)/%.traineddata)
-TESSERACT_TRAINEDDATA += $(ALL_TESSERACT_MODELS:%=$(VIRTUAL_ENV)/share/tessdata/%.traineddata)
 
 stripdir = $(patsubst %/,%,$(dir $(1)))
 
@@ -714,10 +717,6 @@ $(TESSDATA)/%.traineddata:
 	$(call WGET,$@,$(TESSDATA_URL)/$(notdir $@)) || \
 	$(call WGET,$@,$(TESSDATA_URL)/$(notdir $(call stripdir,$@))/$(notdir $@)) || \
 		{ $(RM) $@; false; }
-
-$(VIRTUAL_ENV)/share/tessdata/%.traineddata: $(TESSDATA)/%.traineddata
-	@mkdir -p $(dir $@)
-	cp $< $@
 
 tesseract/Makefile.in: tesseract
 	cd tesseract && ./autogen.sh

--- a/Makefile
+++ b/Makefile
@@ -531,8 +531,7 @@ install-models-eynollah:
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-eynollah-segment '*'
 OCRD_EXECUTABLES += $(EYNOLLAH_SEGMENT)
 EYNOLLAH_SEGMENT := $(BIN)/ocrd-eynollah-segment
-EYNOLLAH_SEGMENT += $(BIN)/eynollah
-$(call multirule,$(EYNOLLAH_SEGMENT)): eynollah $(BIN)/ocrd
+$(EYNOLLAH_SEGMENT): eynollah $(BIN)/ocrd
 	$(pip_install)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -464,7 +464,7 @@ install-models-calamari: $(BIN)/ocrd
 	. $(ACTIVATE_VENV) && ocrd resmgr download ocrd-calamari-recognize '*'
 OCRD_EXECUTABLES += $(OCRD_CALAMARI)
 OCRD_CALAMARI := $(BIN)/ocrd-calamari-recognize
-$(OCRD_CALAMARI): ocrd_calamari
+$(OCRD_CALAMARI): ocrd_calamari $(BIN)/ocrd
 	$(pip_install)
 endif
 
@@ -492,7 +492,7 @@ OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-dewarp
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-tiseg
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-textline
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-layout-analysis
-$(call multirule,$(OCRD_ANYBASEOCR)): ocrd_anybaseocr
+$(call multirule,$(OCRD_ANYBASEOCR)): ocrd_anybaseocr $(BIN)/ocrd
 	$(pip_install)
 endif
 
@@ -520,7 +520,7 @@ install-models-sbb-binarization:
 OCRD_EXECUTABLES += $(SBB_BINARIZATION)
 SBB_BINARIZATION := $(BIN)/ocrd-sbb-binarize
 SBB_BINARIZATION += $(BIN)/sbb_binarize
-$(SBB_BINARIZATION): sbb_binarization
+$(call multirule,$(SBB_BINARIZATION)): sbb_binarization $(BIN)/ocrd
 	$(pip_install)
 endif
 
@@ -532,7 +532,7 @@ install-models-eynollah:
 OCRD_EXECUTABLES += $(EYNOLLAH_SEGMENT)
 EYNOLLAH_SEGMENT := $(BIN)/ocrd-eynollah-segment
 EYNOLLAH_SEGMENT += $(BIN)/eynollah
-$(EYNOLLAH_SEGMENT): eynollah
+$(call multirule,$(EYNOLLAH_SEGMENT)): eynollah $(BIN)/ocrd
 	$(pip_install)
 endif
 

--- a/README.md
+++ b/README.md
@@ -333,14 +333,16 @@ This table lists which tag contains which module:
 | format-converters           | -         | ☑        | ☑         |
 | ocrd_calamari               | -         | ☑        | ☑         |
 | ocrd_keraslm                | -         | ☑        | ☑         |
-| ocrd_olahd_client           | -         | ☑        | ☑         |
+| ocrd_olahd_client           | ☑         | ☑        | ☑         |
 | ocrd_olena                  | -         | ☑        | ☑         |
 | ocrd_segment                | -         | ☑        | ☑         |
 | tesseract                   | -         | ☑        | ☑         |
 | ocrd_anybaseocr             | -         | -        | ☑         |
-| ocrd_kraken                 | -         | -        | -         |
+| ocrd_detectron2             | -         | -        | ☑         |
+| ocrd_doxa                   | -         | -        | ☑         |
+| ocrd_kraken                 | -         | -        | ☑         |
 | ocrd_ocropy                 | -         | -        | -         |
-| ocrd_pc_segmentation        | -         | -        | ☑         |
+| ocrd_pc_segmentation        | -         | -        | -         |
 | ocrd_typegroups_classifier  | -         | -        | ☑         |
 | sbb_binarization            | -         | -        | ☑         |
 | cor-asv-fst                 | -         | -        | -         |
@@ -350,8 +352,6 @@ enabled by explicitly setting `OCRD_MODULES` or `DISABLED_MODULES`:
 
 * cor-asv-fst (runtime issues)
 * ocrd_ocropy (better implementation in ocrd_cis available)
-* ocrd_kraken (currently unmaintained)
-* clstm (required only for ocrd_kraken)
 
 ### Uninstall
 
@@ -373,7 +373,6 @@ This repo offers solutions to the following problems with OCR-D integration.
 
 The following Python modules need an installation from code for different reasons:
 
-- clstm (needs modified code for Python3)
 - cor-asv-ann (not available in PyPI)
 - cor-asv-fst (not available in PyPI)
 - dinglehopper (not available in PyPI)
@@ -417,7 +416,6 @@ _(Solved by managing and delegating to different subsets of venvs.)_
 
 Not all modules advertise their system package requirements via `make deps-ubuntu`.
 
-- `clstm`: depends on `scons libprotobuf-dev protobuf-compiler libpng-dev libeigen3-dev swig`
 - `tesseract` (when installing from source not PPA): depends on `libleptonica-dev` etc
 
 _(Solved by maintaining these requirements under `deps-ubuntu` here.)_


### PR DESCRIPTION
This adapts to https://github.com/OCR-D/ocrd_tesserocr/pull/187, which will be integrated with https://github.com/OCR-D/ocrd_all/pull/335, on the data/model side: `install-tesseract` and `install-tesseract-models` used to be split between OCR-D resource location and Tesseract tessdata prefix. Since this has become one again, there is no need for elaborate duplication and customization. We simply let the processor and resmgr use the compile-time tessdata/module dir, which is based on the venv as prefix.

Also updates some of the executable lists of other modules.

Proposed course of action: merge this branch into #335 (after additional fixes to core have been merged there).