### PR TITLE
Fix GitHub action for docker build

### DIFF
--- a/.github/workflows/makedocker.yml
+++ b/.github/workflows/makedocker.yml
@@ -63,22 +63,11 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Show Python3 version
       run: python3 --version
-    - name: Show disk usage of Homebrew, Android and .NET
-      run: sudo du -mscx /home/linuxbrew /usr/local/lib/android /usr/share/dotnet 2>/dev/null || true
     - name: Remove Docker images
       run: |
            df -h
            docker images
-           docker rmi alpine:3.12 alpine:3.13 alpine:3.14
-           docker rmi buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye
-           docker rmi debian:9 debian:10 debian:11
-           docker rmi moby/buildkit:latest
-           docker rmi node:12-alpine node:14-alpine node:16-alpine
-           docker rmi node:12 node:14 node:16
-           if false; then # don't remove Ubuntu images
-           docker rmi ubuntu:16.04 ubuntu:18.04 ubuntu:20.04
-           fi
-           docker images
+           docker rmi $(docker images -q)
            df -h /
     - name: Remove unneeded Debian packages
       run: |
@@ -102,7 +91,7 @@ jobs:
            # https://github.com/actions/virtual-environments/issues/2606#issuecomment-772683150
            # NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
            sudo rm -rf /home/linuxbrew # will release Homebrew
-           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+           sudo rm -rf /usr/local/lib/android # will release about 11 GB if you don't need Android
            sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
            sudo du -mscx /* 2>/dev/null || true
            df -h /


### PR DESCRIPTION
- Remove the time consuming calculation of used disk space.
- Remove all container images (more robust than removing single images).