### PR TITLE
Revert "Only run pip check once per virtual environment"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -722,10 +722,7 @@ show:
 	@echo OCRD_EXECUTABLES = $(OCRD_EXECUTABLES:$(BIN)/%=%)
 
 check: $(OCRD_EXECUTABLES:%=%-check) $(OCRD_MODULES:%=%-check)
-ifeq (0,$(MAKELEVEL))
 	. $(ACTIVATE_VENV) && pip check
-	. $(SUB_VENV_TF1)/bin/activate && pip check
-endif
 %-check: ;
 
 .PHONY: testcuda test-cuda test-assets test-workflow


### PR DESCRIPTION
(This change was broken: pip check did already run once per venv, but the sub-venv is not always available, e.g. in [minimum](https://email.circleci.com/c/eJxEjs1qtDAYRq_mdRcxUaNZuJjvc6R00UKh6yEmUd9OfiTG-bv6UqbQ7cNzDkd3LRdtZjrKW96UomIiW7qxoLJq-KjpONYVawwVgpZ1VTSCTg0VGXb_4ufXy9t8fA2S3hw_enfp4yH_09SsgqpYw5akzRVGZQ2xZpbqTnxIOKGJ5EJJrRXnWrWCE70sj1tmuyWldYPyAGwANjxRhbkKDtgwL8CG9_8fpAc2BBX1SVoLbKC0KaAc9uROSrpV4uyh7K8hnicbrmSSaI0Gxn8OzmjcHZS9cRLt77iFPSoDZf-sUzJh8FnsNqmW3W_nO1QF-ilEJxOe890jsQbXB865Nt8BAAD__xeeaco), so recursion is cleaner.)

This reverts commit 572ca369c367e3a932a957edd509f4a37c778303.