### PR TITLE
avoid PYTHON_VERSION checks to disable modules in docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ jobs:
   deploy:
     docker:
       - image: cimg/base:current-22.04
-    environment:
-      GIT_DEPTH: "--depth 1"
     parameters:
       variant:
         type:

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ OCRD_EXECUTABLES = $(BIN)/ocrd # add more CLIs below
 CUSTOM_DEPS = unzip wget parallel git less # add more packages for deps-ubuntu below (or modules as preqrequisites)
 
 DEFAULT_DISABLED_MODULES = cor-asv-fst opencv-python ocrd_ocropy ocrd_pc_segmentation
+ifeq ($(filter docker-%,$(MAKECMDGOALS)),)
 ifneq ($(PYTHON_VERSION),3.6)
 ifneq ($(PYTHON_VERSION),3.7)
 ifneq ($(PYTHON_VERSION),3.8)
@@ -80,6 +81,7 @@ endif
 ifeq ($(PYTHON_VERSION),3.10)
 # Python 3.10.x does not work with current kraken.
 DEFAULT_DISABLED_MODULES += ocrd_kraken
+endif
 endif
 DISABLED_MODULES ?= $(DEFAULT_DISABLED_MODULES)
 


### PR DESCRIPTION
this will settle the remaining CI failures (CircleCI cimg ships Python 3.10, so modules like ocrd_kraken and cor-asv-ann had been disabled)