### PR TITLE
docker: build ocrd-all-tool.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,9 @@ RUN ldconfig
 RUN make -j4 check CHECK_HELP=1
 RUN if echo $BASE_IMAGE | fgrep -q cuda; then make fix-cuda; fi
 
+# preinstall ocrd-all-tool.json
+RUN make ocrd-all-tool.json
+
 # remove (dated) security workaround preventing use of
 # ImageMagick's convert on PDF/PS/EPS/XPS:
 RUN sed -i 's/rights="none"/rights="read|write"/g' /etc/ImageMagick-6/policy.xml || true


### PR DESCRIPTION
This will provide /build/ocrd-all-tool.json as part of every prebuilt Docker image (so it won't have to be downloaded).

Still unclear to me exactly how we are going to integrate this in core (to save time looking for processor executables and dump their jsons, or for the Processing Server). But let's start right here.