### PR TITLE
Docker: enable METS caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ ENV XDG_CONFIG_HOME /usr/local/share/ocrd-resources
 # see below (after make all) for an ex-post symlink to /models
 ENV HOME /
 
+# enable caching in OcrdMets for better performance
+ENV OCRD_METS_CACHING=1
+
 # make apt run non-interactive during build
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Backed by successful prior test of:

    docker run --gpus all --rm -v ocrd-models:/models -e OCRD_METS_CACHING=1 -it docker.io/ocrd/all:maximum-cuda make -C /build test-cuda test-workflow

Perhaps we should also make that the default for native installations? For example, we could patch the venv's `activate` script here: https://github.com/OCR-D/ocrd_all/blob/700747559975bb6c2993fac256adfa22dd4d01e4/Makefile#L218