### PR TITLE
Build ocrd_kraken also for latest Python versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,14 +76,6 @@ ifneq ($(PYTHON_VERSION),3.8)
 DEFAULT_DISABLED_MODULES += cor-asv-ann ocrd_keraslm
 endif
 endif
-ifeq ($(PYTHON_VERSION),3.10)
-# Python 3.10.x does not work with current kraken.
-DEFAULT_DISABLED_MODULES += ocrd_kraken
-endif
-ifeq ($(PYTHON_VERSION),3.11)
-# Python 3.11.x does not work with current kraken.
-DEFAULT_DISABLED_MODULES += ocrd_kraken
-endif
 endif
 DISABLED_MODULES ?= $(DEFAULT_DISABLED_MODULES)
 


### PR DESCRIPTION
Python 3.10 and 3.11 now are supported by current kraken.