### PR TITLE
update 2023-12-15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+## [v2023-12-15](https://github.com/OCR-D/ocrd_all/releases/v2023-12-15)
+
+### [core](https://github.com/OCR-D/core) [742906e](https://github.com/OCR-D/core/commits/742906e)..[4684d48](https://github.com/OCR-D/core/commits/4684d48)
+
+> Release: [v2.60.0](https://github.com/OCR-D/core/releases/v2.60.0)
+
+  > * :memo: changelog
+  > * Merge branch 'git-versioning'
+  > * :memo: changelog
+  > * defaults for mets_basename and mets_server_url
+  > * Merge branch 'master' of https://github.com/OCR-D/core
+  > * :memo: changelog
+  > * ocrd workpace list-page: ignore files without pageId, fix #1148
+
 ## [v2023-12-07](https://github.com/OCR-D/ocrd_all/releases/v2023-12-07)
 
 ### [core](https://github.com/OCR-D/core) [d8c5813](https://github.com/OCR-D/core/commits/d8c5813)..[742906e](https://github.com/OCR-D/core/commits/742906e)
@@ -208,8 +224,6 @@
   > * require ocrd >= 2.58
   > * ocrd-page-transform: support --mets-server-url
 
-
-## Unreleased
 
 ## [v2023-10-18](https://github.com/OCR-D/ocrd_all/releases/v2023-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ## [v2023-12-15](https://github.com/OCR-D/ocrd_all/releases/v2023-12-15)
 
-### [core](https://github.com/OCR-D/core) [742906e](https://github.com/OCR-D/core/commits/742906e)..[4684d48](https://github.com/OCR-D/core/commits/4684d48)
+### [core](https://github.com/OCR-D/core) [742906e](https://github.com/OCR-D/core/commits/742906e)..[ac1f15b](https://github.com/OCR-D/core/commits/ac1f15b)
 
-> Release: [v2.60.0](https://github.com/OCR-D/core/releases/v2.60.0)
+> Release: [v2.60.1](https://github.com/OCR-D/core/releases/v2.60.1)
 
+  > * :package: v2.60.1
+  > * docker: we need .git during build for setuptools_scm
   > * :memo: changelog
   > * Merge branch 'git-versioning'
   > * :memo: changelog


### PR DESCRIPTION
This is an incremental release, just updating core to the newest v2.60.0. We have fixed issues with the processing server hanging due to undeployed processing workers, improved the `ocrd workspace list-page` chunking algorithm and, crucially, we changed the setup to use `pyproject.toml` and derive version from git.

Unfortunately, the docker deployment of core did not work, so will need to debug this until it does, then revisit here.