### PR TITLE
release-dockerhub: create aliases maximum{,-cuda}-YYYY-MM-DD, fix #401

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -163,7 +163,11 @@ release_github () {
 
 release_dockerhub () {
     docker tag ocrd/all:maximum-cuda ocrd/all:${version#v}
+    docker tag ocrd/all:maximum ocrd/all:maximum-${version#v}
+    docker tag ocrd/all:maximum-cuda ocrd/all:maximum-cuda-${version#v}
     docker push ocrd/all:${version#v}
+    docker push ocrd/all:maximum-${version#v}
+    docker push ocrd/all:maximum-cuda-${version#v}
     docker tag ocrd/all:maximum-cuda ocrd/all:latest
     docker push ocrd/all:latest
 }


### PR DESCRIPTION
With this PR, two additional aliases for docker tags:

* `maximum-YYYY-MM-dd -> maximum`
* `maximum-cuda-YYYY-MM-dd -> maximum-cuda`

The first one to enable users of the non-CUDA maximum version to use a date-based tag for reproducibility.

The second one for consistency.