### PR TITLE
Fix build for ocrd_tesserocr (fixes issue #420)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ TESSTRAIN_EXECUTABLES += $(BIN)/text2image
 TESSTRAIN_EXECUTABLES += $(BIN)/unicharset_extractor
 TESSTRAIN_EXECUTABLES += $(BIN)/wordlist2dawg
 $(call multirule,$(OCRD_TESSEROCR)): ocrd_tesserocr $(BIN)/ocrd
-	$(MAKE) -C $< install # install-tesseract-training
+	. $(ACTIVATE_VENV) && $(MAKE) -C $< install # install-tesseract-training
 
 endif
 clean: clean-tesseract


### PR DESCRIPTION
`make all` did not build ocrd_tesserocr if it was started without a virtual Python environment because ocrd_tesserocr requires a venv for building.