### PR TITLE
Update several GitHub actions

### DIFF
--- a/.github/workflows/makeall-linux.yaml
+++ b/.github/workflows/makeall-linux.yaml
@@ -34,8 +34,8 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     #    architecture: x64

--- a/.github/workflows/makedocker.yml
+++ b/.github/workflows/makedocker.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Remove Docker images
       run: |
            df -h
@@ -85,7 +85,7 @@ jobs:
            make ocrd-all-tool.json
            wc -l ocrd-all-tool.json
     - name: Upload ocrd-all-tool.json
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ github.event.inputs.docker-image }}_ocrd-all-tool.json
         path: ./ocrd-all-tool.json


### PR DESCRIPTION
The old versions cause a warning:

    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20:
    actions/checkout@v3, actions/setup-python@v4.

For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.