### PR TITLE
Clean network logging in dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,9 @@ RUN sed -i '/width\|height/s/value="16KP"/value="64KP"/' /etc/ImageMagick-6/poli
 # cannot just set ENV, because internal bashrc will override it anyway
 RUN echo "PS1='\w\$ '" >> /etc/bash.bashrc
 
+# clean possibly created log-files & -folders of ocrd_network logger to prevent permission problems
+RUN rm -rf /tmp/ocrd_*
+
 # reset to interactive
 ENV DEBIAN_FRONTEND teletype
 


### PR DESCRIPTION
Fixes #426

This pr removes the possibly created (while creating the docker image) log-file and folders so that when an docker container with ocrd is created no logfiles and folders exist and thus are created with permissions of the user starting the docker container.

Alternative to https://github.com/OCR-D/core/pull/1214